### PR TITLE
fix: Correct AddressRequest partial typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -40,15 +40,15 @@ export type Address = {
   iso: string
   iso_state: string
   notes: string
+  meta?: {[key: string]: any}
 }
 
 export type AddressRequest = Partial<Address> & {
-  address_line_2?: string
-  address_line_3?: string
-  company?: string
-  is_default?: Boolean
-  latitude?: string
-  longitude?: string
+  address_line_1: string
+  city: string,
+  postcode: string,
+  country: string,
+  state: string
 }
 
 export type AddressUpdateRequest = {


### PR DESCRIPTION
This will resolve issue #2 

The typings in the AddressRequest will now show the correct required fields