### PR TITLE
feat: add TXN update-create

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          OMNEO_TENANT: ${{secrets.OMNEO_SANDBOX_TENANT}}
+          OMNEO_TOKEN: ${{secrets.OMNEO_SANDBOX_GH_ACTIONS_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment: test
-    needs: build
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment: test
+    needs: build
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -18,3 +19,7 @@ jobs:
         env:
           OMNEO_TENANT: ${{secrets.OMNEO_SANDBOX_TENANT}}
           OMNEO_TOKEN: ${{secrets.OMNEO_SANDBOX_GH_ACTIONS_TOKEN}}
+          OMNEO_TEST_PROFILE_ID: ${{secrets.OMNEO_TEST_PROFILE_ID}}
+          OMNEO_TEST_LOCATION_ID: ${{secrets.OMNEO_TEST_LOCATION_ID}}
+          OMNEO_TEST_PRODUCT_ID: ${{secrets.OMNEO_TEST_PRODUCT_ID}}
+          OMNEO_TEST_PRODUCT_VARIANT_ID: ${{secrets.OMNEO_TEST_PRODUCT_VARIANT_ID}}

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Stores config for IntelliJ-based IDEs
+.idea
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A JavaScript Library to interface with the [Omneo API](https://omneo.readme.io/r
 
 # Getting started
 
-To get started with the Omneo SDK, follow the instructions below
+To get started with the Omneo SDK, follow the instructions below:
 
 - [Installation](#installation)
 - [Authentication](#authentication)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@omneo/omneo-sdk",
-  "version": "1.28.0",
+  "version": "1.28.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@omneo/omneo-sdk",
-      "version": "1.28.0",
+      "version": "1.28.2",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^18.11.11"
+        "@types/node": "^18.11.11",
+        "vitest": "^2.1.4"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -1195,8 +1196,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1442,7 +1442,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1455,7 +1454,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1468,7 +1466,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1481,7 +1478,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1494,7 +1490,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1507,7 +1502,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1520,7 +1514,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1533,7 +1526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1546,7 +1538,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1559,7 +1550,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1572,7 +1562,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1585,7 +1574,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1598,7 +1586,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1611,7 +1598,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1624,7 +1610,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1637,7 +1622,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2162,8 +2146,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -2416,6 +2399,112 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
+      "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
+      "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
+      "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
+      "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.4",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
+      "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.4",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
+      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
+      "integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.4",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -2612,6 +2701,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2696,7 +2794,6 @@
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2725,6 +2822,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2749,6 +2862,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3115,7 +3237,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3126,6 +3247,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -3941,6 +4071,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3973,6 +4112,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4212,7 +4360,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5495,11 +5642,26 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
+    "node_modules/loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "node_modules/marked": {
       "version": "12.0.2",
@@ -5647,8 +5809,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -5659,6 +5820,24 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -9223,11 +9402,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9346,6 +9539,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.48",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.48.tgz",
+      "integrity": "sha512-GCRK8F6+Dl7xYniR5a4FYbpBzU8XnZVeowqsQFYdcXuSbChgiks7qybSkbvnaeqv0G0B+dd9/jJgH8kkLDQeEA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -9694,7 +9915,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -10106,6 +10326,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -10240,6 +10466,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -10288,6 +10523,18 @@
       "dependencies": {
         "through2": "~2.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "license": "MIT"
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
@@ -10621,11 +10868,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
-      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
-      "dev": true
+      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.9",
@@ -10664,6 +10916,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+      "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -11041,6 +11320,557 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
+      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
+      "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
+      "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.4",
+        "@vitest/mocker": "2.1.4",
+        "@vitest/pretty-format": "^2.1.4",
+        "@vitest/runner": "2.1.4",
+        "@vitest/snapshot": "2.1.4",
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.4",
+        "@vitest/ui": "2.1.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11072,6 +11902,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -11938,8 +12784,7 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -12122,112 +12967,96 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
       "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-android-arm64": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
       "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-arm64": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
       "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-x64": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
       "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
       "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
       "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-gnu": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
       "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-musl": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
       "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
       "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
       "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-s390x-gnu": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
       "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-gnu": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
       "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
       "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-arm64-msvc": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
       "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-ia32-msvc": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
       "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
-      "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-x64-msvc": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
       "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
-      "dev": true,
       "optional": true
     },
     "@sec-ant/readable-stream": {
@@ -12567,8 +13396,7 @@
     "@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -12715,6 +13543,72 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@vitest/expect": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
+      "integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
+      "requires": {
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/mocker": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
+      "integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
+      "requires": {
+        "@vitest/spy": "2.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      }
+    },
+    "@vitest/pretty-format": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
+      "integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
+      "requires": {
+        "tinyrainbow": "^1.2.0"
+      }
+    },
+    "@vitest/runner": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
+      "integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
+      "requires": {
+        "@vitest/utils": "2.1.4",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/snapshot": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
+      "integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
+      "requires": {
+        "@vitest/pretty-format": "2.1.4",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      }
+    },
+    "@vitest/spy": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
+      "integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
+      "requires": {
+        "tinyspy": "^3.0.2"
+      }
+    },
+    "@vitest/utils": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
+      "integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
+      "requires": {
+        "@vitest/pretty-format": "2.1.4",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      }
+    },
     "acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -12848,6 +13742,11 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -12912,8 +13811,7 @@
     "cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -12931,6 +13829,18 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "requires": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -12946,6 +13856,11 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw=="
     },
     "chokidar": {
       "version": "3.6.0",
@@ -13209,10 +14124,14 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.3"
       }
+    },
+    "deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -13770,6 +14689,14 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "requires": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -13792,6 +14719,11 @@
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       }
+    },
+    "expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -13968,7 +14900,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -14838,11 +15769,24 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
+    "loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg=="
+    },
     "lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "magic-string": {
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "marked": {
       "version": "12.0.2",
@@ -14936,8 +15880,7 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mz": {
       "version": "2.7.0",
@@ -14949,6 +15892,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17362,11 +18310,20 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+    },
+    "pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA=="
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -17445,6 +18402,16 @@
           "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         }
+      }
+    },
+    "postcss": {
+      "version": "8.4.48",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.48.tgz",
+      "integrity": "sha512-GCRK8F6+Dl7xYniR5a4FYbpBzU8XnZVeowqsQFYdcXuSbChgiks7qybSkbvnaeqv0G0B+dd9/jJgH8kkLDQeEA==",
+      "requires": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "prelude-ls": {
@@ -17677,7 +18644,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
       "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
-      "dev": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.24.0",
         "@rollup/rollup-android-arm64": "4.24.0",
@@ -17938,6 +18904,11 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -18037,6 +19008,11 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
+    },
     "spawn-error-forwarder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -18083,6 +19059,16 @@
       "requires": {
         "through2": "~2.0.0"
       }
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
+    "std-env": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w=="
     },
     "stream-combiner2": {
       "version": "1.1.1",
@@ -18314,11 +19300,15 @@
         "convert-hrtime": "^5.0.0"
       }
     },
+    "tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
+    },
     "tinyexec": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
-      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
-      "dev": true
+      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ=="
     },
     "tinyglobby": {
       "version": "0.2.9",
@@ -18344,6 +19334,21 @@
           "dev": true
         }
       }
+    },
+    "tinypool": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
+      "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA=="
+    },
+    "tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="
+    },
+    "tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -18581,6 +19586,225 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "vite": {
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
+      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+      "requires": {
+        "esbuild": "^0.21.3",
+        "fsevents": "~2.3.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "dependencies": {
+        "@esbuild/aix-ppc64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+          "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+          "optional": true
+        },
+        "@esbuild/android-arm": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+          "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+          "optional": true
+        },
+        "@esbuild/android-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+          "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+          "optional": true
+        },
+        "@esbuild/android-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+          "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+          "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+          "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+          "optional": true
+        },
+        "@esbuild/darwin-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+          "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+          "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+          "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+          "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+          "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+          "optional": true
+        },
+        "@esbuild/linux-arm": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+          "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+          "optional": true
+        },
+        "@esbuild/linux-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+          "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+          "optional": true
+        },
+        "@esbuild/linux-ia32": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+          "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+          "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+          "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+          "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+          "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+          "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+          "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+          "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+          "optional": true
+        },
+        "@esbuild/linux-s390x": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+          "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+          "optional": true
+        },
+        "@esbuild/linux-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+          "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+          "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+          "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+          "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+          "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+          "optional": true
+        },
+        "@esbuild/sunos-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+          "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+          "optional": true
+        },
+        "@esbuild/win32-arm64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+          "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+          "optional": true
+        },
+        "@esbuild/win32-ia32": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+          "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+          "optional": true
+        },
+        "@esbuild/win32-x64": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+          "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+          "optional": true
+        },
+        "esbuild": {
+          "version": "0.21.5",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+          "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+          "requires": {
+            "@esbuild/aix-ppc64": "0.21.5",
+            "@esbuild/android-arm": "0.21.5",
+            "@esbuild/android-arm64": "0.21.5",
+            "@esbuild/android-x64": "0.21.5",
+            "@esbuild/darwin-arm64": "0.21.5",
+            "@esbuild/darwin-x64": "0.21.5",
+            "@esbuild/freebsd-arm64": "0.21.5",
+            "@esbuild/freebsd-x64": "0.21.5",
+            "@esbuild/linux-arm": "0.21.5",
+            "@esbuild/linux-arm64": "0.21.5",
+            "@esbuild/linux-ia32": "0.21.5",
+            "@esbuild/linux-loong64": "0.21.5",
+            "@esbuild/linux-mips64el": "0.21.5",
+            "@esbuild/linux-ppc64": "0.21.5",
+            "@esbuild/linux-riscv64": "0.21.5",
+            "@esbuild/linux-s390x": "0.21.5",
+            "@esbuild/linux-x64": "0.21.5",
+            "@esbuild/netbsd-x64": "0.21.5",
+            "@esbuild/openbsd-x64": "0.21.5",
+            "@esbuild/sunos-x64": "0.21.5",
+            "@esbuild/win32-arm64": "0.21.5",
+            "@esbuild/win32-ia32": "0.21.5",
+            "@esbuild/win32-x64": "0.21.5"
+          }
+        }
+      }
+    },
+    "vite-node": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
+      "integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
+      "requires": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      }
+    },
+    "vitest": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
+      "integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
+      "requires": {
+        "@vitest/expect": "2.1.4",
+        "@vitest/mocker": "2.1.4",
+        "@vitest/pretty-format": "^2.1.4",
+        "@vitest/runner": "2.1.4",
+        "@vitest/snapshot": "2.1.4",
+        "@vitest/spy": "2.1.4",
+        "@vitest/utils": "2.1.4",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.4",
+        "why-is-node-running": "^2.3.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -18601,6 +19825,15 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "watch": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "test": "vitest run",
     "eslint": "eslint index.ts",
     "semantic-release": "npm run build && npx semantic-release --no-ci",
     "lint": "eslint . --ext .ts",
@@ -37,7 +38,8 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@types/node": "^18.11.11"
+    "@types/node": "^18.11.11",
+    "vitest": "^2.1.4"
   },
   "files": [
     "dist/*"

--- a/src/omneo/index.ts
+++ b/src/omneo/index.ts
@@ -53,7 +53,7 @@ export class Omneo {
     })
 
     if (!response.ok) {
-      throw new Error(`Request failed with status ${response.status}`)
+      throw new Error(`Request failed with status ${response.status}. ${response.statusText}`)
     }
     try {
       const data = await response.json()

--- a/src/omneo/resources/transactions/index.ts
+++ b/src/omneo/resources/transactions/index.ts
@@ -1,4 +1,4 @@
-import { RequestParams, Transaction } from '../../../types'
+import {RequestParams, Transaction, TransactionInput} from '../../../types'
 import Resource from '../resource'
 
 export default class Transactions extends Resource {
@@ -42,7 +42,7 @@ export default class Transactions extends Resource {
     })
   }
 
-  updateCreate (body: any): Promise<Transaction> {
+  updateCreate (body: TransactionInput): Promise<Transaction> {
     return this.client.call({
       method: 'post',
       endpoint: `/transactions/update-create`,

--- a/src/omneo/resources/transactions/index.ts
+++ b/src/omneo/resources/transactions/index.ts
@@ -1,4 +1,4 @@
-import {RequestParams, Transaction, TransactionInput} from '../../../types'
+import { RequestParams, Transaction, TransactionInput } from '../../../types'
 import Resource from '../resource'
 
 export default class Transactions extends Resource {
@@ -45,7 +45,7 @@ export default class Transactions extends Resource {
   updateCreate (body: TransactionInput): Promise<Transaction> {
     return this.client.call({
       method: 'post',
-      endpoint: `/transactions/update-create`,
+      endpoint: '/transactions/update-create',
       body
     }).then((response) => {
       return response.data

--- a/src/omneo/resources/transactions/index.ts
+++ b/src/omneo/resources/transactions/index.ts
@@ -32,6 +32,26 @@ export default class Transactions extends Resource {
     })
   }
 
+  update (id: string, body: any): Promise<Transaction> {
+    return this.client.call({
+      method: 'put',
+      endpoint: `/transactions/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  updateCreate (body: any): Promise<Transaction> {
+    return this.client.call({
+      method: 'post',
+      endpoint: `/transactions/update-create`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
   delete (id: string): Promise<Transaction> {
     return this.client.call({
       method: 'delete',
@@ -48,16 +68,6 @@ export default class Transactions extends Resource {
       params
     }).then((response: any) => {
       return response
-    })
-  }
-
-  update (id: string, body: any): Promise<Transaction> {
-    return this.client.call({
-      method: 'put',
-      endpoint: `/transactions/${id}`,
-      body
-    }).then((response) => {
-      return response.data
     })
   }
 

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -1,35 +1,35 @@
-import {afterEach, expect, test} from "vitest";
-import { writeTransaction } from "../../mocks/transactions/transaction";
-import simpleOmneoRequest from "../../lib/simple-omneo-request";
-import {Omneo} from "../../../omneo";
-import randomString from "../../lib/string/random";
+import { afterEach, expect, test } from 'vitest'
+import { writeTransaction } from '../../mocks/transactions/transaction'
+import simpleOmneoRequest from '../../lib/simple-omneo-request'
+import { Omneo } from '../../../omneo'
+import randomString from '../../lib/string/random'
 
 let NEW_TRANSACTION_ID : number | null = null
 const EXTERNAL_ID = randomString(9)
 
 const omneo = new Omneo({
-    tenant: process.env.OMNEO_TENANT as string,
-    token: process.env.OMNEO_TOKEN as string
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
 })
 
-test("SDK can write a transaction to Omneo.", async () => {
-    writeTransaction.external_id = EXTERNAL_ID
+test('SDK can write a transaction to Omneo.', async () => {
+  writeTransaction.external_id = EXTERNAL_ID
 
-    const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransaction)
+  const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransaction)
 
-    expect(sdkCreateTransaction.external_id).toBe(EXTERNAL_ID)
-    expect(sdkCreateTransaction.tags).toStrictEqual(writeTransaction.tags)
-    expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransaction.receipt_ref)
-    NEW_TRANSACTION_ID = sdkCreateTransaction.id
+  expect(sdkCreateTransaction.external_id).toBe(EXTERNAL_ID)
+  expect(sdkCreateTransaction.tags).toStrictEqual(writeTransaction.tags)
+  expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransaction.receipt_ref)
+  NEW_TRANSACTION_ID = sdkCreateTransaction.id
 })
 
 afterEach(async () => {
-    // Delete the test transaction.
-    if(NEW_TRANSACTION_ID) {
-        console.log('Cleaning up transaction', NEW_TRANSACTION_ID);
-        const deleteResponse = await simpleOmneoRequest("DELETE", `/transactions/${NEW_TRANSACTION_ID}`);
-        if(deleteResponse.status === 204) {
-            console.log(`Transaction ${NEW_TRANSACTION_ID} deleted`);
-        }
+  // Delete the test transaction.
+  if (NEW_TRANSACTION_ID) {
+    console.log('Cleaning up transaction', NEW_TRANSACTION_ID)
+    const deleteResponse = await simpleOmneoRequest('DELETE', `/transactions/${NEW_TRANSACTION_ID}`)
+    if (deleteResponse.status === 204) {
+      console.log(`Transaction ${NEW_TRANSACTION_ID} deleted`)
     }
+  }
 })

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -52,8 +52,8 @@ describe('Transactions update-create', () => {
     newTransaction.total = 200
 
     // TODO: Find out why these is required for a TXN update but not create.
-    newTransaction.receipt_is_email = true
-    newTransaction.is_void = false
+    // newTransaction.receipt_is_email = true
+    // newTransaction.is_void = false
 
     const sdkCreateTransaction = await omneo.transactions.updateCreate(newTransaction)
     expect(sdkCreateTransaction.tags).toStrictEqual(newTransaction.tags)

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from 'vitest'
+import { describe, test, afterAll, expect } from 'vitest'
 import { writeTransactionWithVariant, writeTransactionWithVariantID } from '../../mocks/transactions/transaction'
 import simpleOmneoRequest from '../../lib/simple-omneo-request'
 import { Omneo } from '../../../omneo'
@@ -11,29 +11,57 @@ const omneo = new Omneo({
   token: process.env.OMNEO_TOKEN as string
 })
 
-test('SDK can write a transaction with a variant to Omneo.', async () => {
-  writeTransactionWithVariant.external_id = randomString(9)
+describe('Transactions update-create', () => {
+  test('SDK can create a transaction with a variant to Omneo.', async () => {
+    writeTransactionWithVariant.external_id = randomString(9)
 
-  const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransactionWithVariant)
+    const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransactionWithVariant)
+    CREATED_TRANSACTION_IDS.push(sdkCreateTransaction.id)
 
-  expect(sdkCreateTransaction.external_id).toBe(writeTransactionWithVariant.external_id)
-  expect(sdkCreateTransaction.tags).toStrictEqual(writeTransactionWithVariant.tags)
-  expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransactionWithVariant.receipt_ref)
-  CREATED_TRANSACTION_IDS.push(sdkCreateTransaction.id)
+    expect(sdkCreateTransaction.external_id).toBe(writeTransactionWithVariant.external_id)
+    expect(sdkCreateTransaction.tags).toStrictEqual(writeTransactionWithVariant.tags)
+    expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransactionWithVariant.receipt_ref)
+  })
+
+  test('SDK can create a transaction with a variant ID Omneo.', async () => {
+    writeTransactionWithVariantID.external_id = randomString(9)
+
+    const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransactionWithVariantID)
+    CREATED_TRANSACTION_IDS.push(sdkCreateTransaction.id)
+
+    expect(sdkCreateTransaction.external_id).toBe(writeTransactionWithVariantID.external_id)
+    expect(sdkCreateTransaction.tags).toStrictEqual(writeTransactionWithVariantID.tags)
+    expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransactionWithVariantID.receipt_ref)
+  })
+
+  test('SDK can update a transaction Omneo.', async () => {
+    writeTransactionWithVariantID.external_id = randomString(9)
+
+    const testTransactionResponse = await simpleOmneoRequest('POST', '/transactions', writeTransactionWithVariantID)
+
+    const newTransaction = testTransactionResponse.data
+
+    newTransaction.meta = {
+      ...newTransaction.meta,
+      updated: 'updated'
+    }
+    newTransaction.tags = [
+      ...newTransaction.tags,
+      'updated'
+    ]
+    newTransaction.total = 200
+
+    // TODO: Find out why these is required for a TXN update but not create.
+    newTransaction.receipt_is_email = true
+    newTransaction.is_void = false
+
+    const sdkCreateTransaction = await omneo.transactions.updateCreate(newTransaction)
+    expect(sdkCreateTransaction.tags).toStrictEqual(newTransaction.tags)
+    expect(sdkCreateTransaction.total).toBe(200)
+  })
 })
 
-test('SDK can write a transaction with a variant ID Omneo.', async () => {
-  writeTransactionWithVariantID.external_id = randomString(9)
-
-  const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransactionWithVariantID)
-
-  expect(sdkCreateTransaction.external_id).toBe(writeTransactionWithVariantID.external_id)
-  expect(sdkCreateTransaction.tags).toStrictEqual(writeTransactionWithVariantID.tags)
-  expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransactionWithVariantID.receipt_ref)
-  CREATED_TRANSACTION_IDS.push(sdkCreateTransaction.id)
-})
-
-afterEach(async () => {
+afterAll(async () => {
   // Delete the test transaction.
   if (CREATED_TRANSACTION_IDS.length > 0) {
     for (const transactionId of CREATED_TRANSACTION_IDS) {

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from 'vitest'
-import {writeTransactionWithVariant, writeTransactionWithVariantID} from '../../mocks/transactions/transaction'
+import { writeTransactionWithVariant, writeTransactionWithVariantID } from '../../mocks/transactions/transaction'
 import simpleOmneoRequest from '../../lib/simple-omneo-request'
 import { Omneo } from '../../../omneo'
 import randomString from '../../lib/string/random'

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -1,35 +1,47 @@
 import { afterEach, expect, test } from 'vitest'
-import { writeTransaction } from '../../mocks/transactions/transaction'
+import {writeTransactionWithVariant, writeTransactionWithVariantID} from '../../mocks/transactions/transaction'
 import simpleOmneoRequest from '../../lib/simple-omneo-request'
 import { Omneo } from '../../../omneo'
 import randomString from '../../lib/string/random'
 
-let NEW_TRANSACTION_ID : number | null = null
-const EXTERNAL_ID = randomString(9)
+const CREATED_TRANSACTION_IDS : number[] = []
 
 const omneo = new Omneo({
   tenant: process.env.OMNEO_TENANT as string,
   token: process.env.OMNEO_TOKEN as string
 })
 
-test('SDK can write a transaction to Omneo.', async () => {
-  writeTransaction.external_id = EXTERNAL_ID
+test('SDK can write a transaction with a variant to Omneo.', async () => {
+  writeTransactionWithVariant.external_id = randomString(9)
 
-  const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransaction)
+  const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransactionWithVariant)
 
-  expect(sdkCreateTransaction.external_id).toBe(EXTERNAL_ID)
-  expect(sdkCreateTransaction.tags).toStrictEqual(writeTransaction.tags)
-  expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransaction.receipt_ref)
-  NEW_TRANSACTION_ID = sdkCreateTransaction.id
+  expect(sdkCreateTransaction.external_id).toBe(writeTransactionWithVariant.external_id)
+  expect(sdkCreateTransaction.tags).toStrictEqual(writeTransactionWithVariant.tags)
+  expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransactionWithVariant.receipt_ref)
+  CREATED_TRANSACTION_IDS.push(sdkCreateTransaction.id)
+})
+
+test('SDK can write a transaction with a variant ID Omneo.', async () => {
+  writeTransactionWithVariantID.external_id = randomString(9)
+
+  const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransactionWithVariantID)
+
+  expect(sdkCreateTransaction.external_id).toBe(writeTransactionWithVariantID.external_id)
+  expect(sdkCreateTransaction.tags).toStrictEqual(writeTransactionWithVariantID.tags)
+  expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransactionWithVariantID.receipt_ref)
+  CREATED_TRANSACTION_IDS.push(sdkCreateTransaction.id)
 })
 
 afterEach(async () => {
   // Delete the test transaction.
-  if (NEW_TRANSACTION_ID) {
-    console.log('Cleaning up transaction', NEW_TRANSACTION_ID)
-    const deleteResponse = await simpleOmneoRequest('DELETE', `/transactions/${NEW_TRANSACTION_ID}`)
-    if (deleteResponse.status === 204) {
-      console.log(`Transaction ${NEW_TRANSACTION_ID} deleted`)
+  if (CREATED_TRANSACTION_IDS.length > 0) {
+    for (const transactionId of CREATED_TRANSACTION_IDS) {
+      console.log('Cleaning up transaction', transactionId)
+      const deleteResponse = await simpleOmneoRequest('DELETE', `/transactions/${transactionId}`)
+      if (deleteResponse.status === 204) {
+        console.log(`Transaction ${transactionId} deleted`)
+      }
     }
   }
 })

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -1,0 +1,35 @@
+import {afterEach, expect, test} from "vitest";
+import { writeTransaction } from "../../mocks/transactions/transaction";
+import simpleOmneoRequest from "../../lib/simple-omneo-request";
+import {Omneo} from "../../../omneo";
+import randomString from "../../lib/string/random";
+
+let NEW_TRANSACTION_ID : number | null = null
+const EXTERNAL_ID = randomString(9)
+
+const omneo = new Omneo({
+    tenant: process.env.OMNEO_TENANT as string,
+    token: process.env.OMNEO_TOKEN as string
+})
+
+test("SDK can write a transaction to Omneo.", async () => {
+    writeTransaction.external_id = EXTERNAL_ID
+
+    const sdkCreateTransaction = await omneo.transactions.updateCreate(writeTransaction)
+
+    expect(sdkCreateTransaction.external_id).toBe(EXTERNAL_ID)
+    expect(sdkCreateTransaction.tags).toStrictEqual(writeTransaction.tags)
+    expect(sdkCreateTransaction.receipt_ref).toStrictEqual(writeTransaction.receipt_ref)
+    NEW_TRANSACTION_ID = sdkCreateTransaction.id
+})
+
+afterEach(async () => {
+    // Delete the test transaction.
+    if(NEW_TRANSACTION_ID) {
+        console.log('Cleaning up transaction', NEW_TRANSACTION_ID);
+        const deleteResponse = await simpleOmneoRequest("DELETE", `/transactions/${NEW_TRANSACTION_ID}`);
+        if(deleteResponse.status === 204) {
+            console.log(`Transaction ${NEW_TRANSACTION_ID} deleted`);
+        }
+    }
+})

--- a/src/tests/integration/transactions/update-create-transaction.test.ts
+++ b/src/tests/integration/transactions/update-create-transaction.test.ts
@@ -52,8 +52,8 @@ describe('Transactions update-create', () => {
     newTransaction.total = 200
 
     // TODO: Find out why these is required for a TXN update but not create.
-    // newTransaction.receipt_is_email = true
-    // newTransaction.is_void = false
+    newTransaction.receipt_is_email = true
+    newTransaction.is_void = false
 
     const sdkCreateTransaction = await omneo.transactions.updateCreate(newTransaction)
     expect(sdkCreateTransaction.tags).toStrictEqual(newTransaction.tags)

--- a/src/tests/lib/simple-omneo-request.ts
+++ b/src/tests/lib/simple-omneo-request.ts
@@ -1,23 +1,23 @@
 const TENANT = process.env.OMNEO_TENANT
 const TOKEN = process.env.OMNEO_TOKEN
 
-export default function simpleOmneoRequest(method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, body?: any) {
-    return fetch(`https://api.${TENANT}.getomneo.com/api/v3${endpoint}`, {
-        method,
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${TOKEN}`
-        }
-    }).then(response => {
-        if(response.status === 204) {
-            // Omneo delete operations just return 204 with no body.
-            return {
-                status: response.status,
-                statusText: response.statusText
-            }
-        }
-        return response.json()
-    }).catch(error => {
-        console.log('Simple Omneo request function error', error);
-    });
+export default function simpleOmneoRequest (method: 'GET' | 'POST' | 'PUT' | 'DELETE', endpoint: string, body?: any) {
+  return fetch(`https://api.${TENANT}.getomneo.com/api/v3${endpoint}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`
+    }
+  }).then(response => {
+    if (response.status === 204) {
+      // Omneo delete operations just return 204 with no body.
+      return {
+        status: response.status,
+        statusText: response.statusText
+      }
+    }
+    return response.json()
+  }).catch(error => {
+    console.log('Simple Omneo request function error', error)
+  })
 }

--- a/src/tests/lib/simple-omneo-request.ts
+++ b/src/tests/lib/simple-omneo-request.ts
@@ -1,14 +1,25 @@
 const TENANT = process.env.OMNEO_TENANT
 const TOKEN = process.env.OMNEO_TOKEN
-
+type RequestInit = {
+    method: string
+    headers: {
+        'Content-Type': string
+        Authorization: string
+    }
+    body?: string
+}
 export default function simpleOmneoRequest (method: 'GET' | 'POST' | 'PUT' | 'DELETE', endpoint: string, body?: any) {
-  return fetch(`https://api.${TENANT}.getomneo.com/api/v3${endpoint}`, {
+  const options: RequestInit = {
     method,
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${TOKEN}`
     }
-  }).then(response => {
+  }
+  if (body) {
+    options.body = JSON.stringify(body)
+  }
+  return fetch(`https://api.${TENANT}.getomneo.com/api/v3${endpoint}`, options).then(response => {
     if (response.status === 204) {
       // Omneo delete operations just return 204 with no body.
       return {

--- a/src/tests/lib/simple-omneo-request.ts
+++ b/src/tests/lib/simple-omneo-request.ts
@@ -1,0 +1,23 @@
+const TENANT = process.env.OMNEO_TENANT
+const TOKEN = process.env.OMNEO_TOKEN
+
+export default function simpleOmneoRequest(method: "GET" | "POST" | "PUT" | "DELETE", endpoint: string, body?: any) {
+    return fetch(`https://api.${TENANT}.getomneo.com/api/v3${endpoint}`, {
+        method,
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${TOKEN}`
+        }
+    }).then(response => {
+        if(response.status === 204) {
+            // Omneo delete operations just return 204 with no body.
+            return {
+                status: response.status,
+                statusText: response.statusText
+            }
+        }
+        return response.json()
+    }).catch(error => {
+        console.log('Simple Omneo request function error', error);
+    });
+}

--- a/src/tests/lib/string/random.ts
+++ b/src/tests/lib/string/random.ts
@@ -1,8 +1,8 @@
-export default function randomString(length: number) {
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    let result = '';
-    for (let i = 0; i < length; i++) {
-        result += characters.charAt(Math.floor(Math.random() * characters.length));
-    }
-    return result;
+export default function randomString (length: number) {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length))
+  }
+  return result
 }

--- a/src/tests/lib/string/random.ts
+++ b/src/tests/lib/string/random.ts
@@ -1,0 +1,8 @@
+export default function randomString(length: number) {
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let result = '';
+    for (let i = 0; i < length; i++) {
+        result += characters.charAt(Math.floor(Math.random() * characters.length));
+    }
+    return result;
+}

--- a/src/tests/mocks/transactions/transaction.ts
+++ b/src/tests/mocks/transactions/transaction.ts
@@ -1,188 +1,188 @@
-import {Transaction, TransactionInput} from "../../../types";
+import { Transaction, TransactionInput } from '../../../types'
 
 export const writeTransaction: TransactionInput = {
-    "profile_id": "9d7796e5-f8a0-4611-aa61-e6872a6a4393",
-    "external_id": "9999999",
-    "receipt_ref": "D172009999999",
-    "location_id": "49",
-    "total": 100,
-    "total_original": 100,
-    "systems": [
-        "CI"
-    ],
-    "tags": [
-        "ci",
-        "test"
-    ],
-    "items": [{
-        "name": "GH ACTION TEST ITEM",
-        "quantity": 1,
-        "price_current": 100,
-        "price_sell": 100,
-        "price_tax": 10,
-        "price_original": 100,
-        "product_variant": {
-            "product_id": 1981205,
-            "sku": "gh-test-action-item-1",
-            "barcode": "GHT-0001",
-            "title": "GH ACTION TEST ITEM 1",
-            "brand": "Omneo",
-            "category": "Testing",
-            "price": 100
-        },
-        "discounts": []
-    }],
-    "payments": [],
-    "timezone": "Australia\/Melbourne",
-    "transacted_at": "2024-11-11 12:00:00",
-    "meta": {
-        "test": "test"
-    }
+  profile_id: '9d7796e5-f8a0-4611-aa61-e6872a6a4393',
+  external_id: '9999999',
+  receipt_ref: 'D172009999999',
+  location_id: '49',
+  total: 100,
+  total_original: 100,
+  systems: [
+    'CI'
+  ],
+  tags: [
+    'ci',
+    'test'
+  ],
+  items: [{
+    name: 'GH ACTION TEST ITEM',
+    quantity: 1,
+    price_current: 100,
+    price_sell: 100,
+    price_tax: 10,
+    price_original: 100,
+    product_variant: {
+      product_id: 1981205,
+      sku: 'gh-test-action-item-1',
+      barcode: 'GHT-0001',
+      title: 'GH ACTION TEST ITEM 1',
+      brand: 'Omneo',
+      category: 'Testing',
+      price: 100
+    },
+    discounts: []
+  }],
+  payments: [],
+  timezone: 'Australia/Melbourne',
+  transacted_at: '2024-11-11 12:00:00',
+  meta: {
+    test: 'test'
+  }
 }
 
 export const readTransaction: Transaction = {
-    "id": 9999999,
-    "external_id": "9999999",
-    "redemption": null,
-    "profile_id": "9a690c37-5bec-44f4-b6b3-8cbe11e46276",
-    "profile": {
-        "email": "subscriptions+githubactions@arkade.com.au"
+  id: 9999999,
+  external_id: '9999999',
+  redemption: null,
+  profile_id: '9a690c37-5bec-44f4-b6b3-8cbe11e46276',
+  profile: {
+    email: 'subscriptions+githubactions@arkade.com.au'
+  },
+  location: {
+    id: 49,
+    type: null,
+    name: null,
+    description: null,
+    phone: null,
+    email: null,
+    external_id: 'GH-ACTIONS',
+    is_published: false,
+    is_permanently_closed: false,
+    address: null
+  },
+  meta: {
+    web_order_number: null
+  },
+  total: 69,
+  total_original: 69,
+  total_converted: 69,
+  systems: [
+    'CI'
+  ],
+  rounding: null,
+  margin: 43,
+  is_void: false,
+  tags: [],
+  items: [{
+    id: 2542,
+    external_id: null,
+    name: 'GH ACTION TEST ITEM',
+    transaction_id: 7479194,
+    product_id: 227266,
+    product_variant_id: 227266,
+    sku: null,
+    variant_external_id: null,
+    is_void: false,
+    quantity: 1,
+    price_current: 100,
+    price_sell: 100,
+    price_original: 100,
+    price_margin: 10,
+    price_tax: 10,
+    discounts: null,
+    department: null,
+    meta: null,
+    product_images: [],
+    order_id: null,
+    created_at: '2024-02-13 04:07:46',
+    updated_at: '2024-02-13 04:07:46',
+    pivot: [],
+    product_variant: {
+      id: 227266,
+      product_id: 227266,
+      sku: '1299388',
+      external_id: 227266,
+      barcode: '',
+      web_url: null,
+      handle: null,
+      title: 'GH ACTION TEST ITEM',
+      description: null,
+      position: 1,
+      price: 100,
+      price_discounted: null,
+      price_comparison: null,
+      price_cost: null,
+      available_quantity: null,
+      images: [],
+      meta: null,
+      tags: [],
+      options: [],
+      created_at: '2024-02-06 20:57:48',
+      updated_at: '2024-02-06 20:57:48'
     },
-    "location": {
-        "id": 49,
-        "type": null,
-        "name": null,
-        "description": null,
-        "phone": null,
-        "email": null,
-        "external_id": "GH-ACTIONS",
-        "is_published": false,
-        "is_permanently_closed": false,
-        "address": null
+    product: {
+      title: 'GH ACTION TEST ITEM',
+      department: null,
+      brand: 'Omneo'
     },
-    "meta": {
-        "web_order_number": null
-    },
-    "total": 69,
-    "total_original": 69,
-    "total_converted": 69,
-    "systems": [
-        "CI"
-    ],
-    "rounding": null,
-    "margin": 43,
-    "is_void": false,
-    "tags": [],
-    "items": [{
-        "id": 2542,
-        "external_id": null,
-        "name": "GH ACTION TEST ITEM",
-        "transaction_id": 7479194,
-        "product_id": 227266,
-        "product_variant_id": 227266,
-        "sku": null,
-        "variant_external_id": null,
-        "is_void": false,
-        "quantity": 1,
-        "price_current": 100,
-        "price_sell": 100,
-        "price_original": 100,
-        "price_margin": 10,
-        "price_tax": 10,
-        "discounts": null,
-        "department": null,
-        "meta": null,
-        "product_images": [],
-        "order_id": null,
-        "created_at": "2024-02-13 04:07:46",
-        "updated_at": "2024-02-13 04:07:46",
-        "pivot": [],
-        "product_variant": {
-            "id": 227266,
-            "product_id": 227266,
-            "sku": "1299388",
-            "external_id": 227266,
-            "barcode": "",
-            "web_url": null,
-            "handle": null,
-            "title": "GH ACTION TEST ITEM",
-            "description": null,
-            "position": 1,
-            "price": 100,
-            "price_discounted": null,
-            "price_comparison": null,
-            "price_cost": null,
-            "available_quantity": null,
-            "images": [],
-            "meta": null,
-            "tags": [],
-            "options": [],
-            "created_at": "2024-02-06 20:57:48",
-            "updated_at": "2024-02-06 20:57:48"
-        },
-        "product": {
-            "title": "GH ACTION TEST ITEM",
-            "department": null,
-            "brand": "Omneo"
-        },
-        "transaction": {
-            "transacted_at": "2024-02-13 01:09:57",
-            "receipt_ref": "D17200109877",
-            "external_id": "36865285"
-        }
-    }],
-    "payments": [{
-        "id": "110943824",
-        "web_order_number": null,
-        "payment_code": "CASH",
-        "paymenttype_id": "506",
-        "payment_number": null,
-        "eftpos_cardtype": null,
-        "tender_value": 69,
-        "eftpos_stan": null,
-        "eftpos_authcode": null,
-        "eftpos_settlement": null,
-        "eftpos_reference": null,
-        "payment_ref1": null,
-        "payment_ref2": null,
-        "payment_ref3": null,
-        "payment_gateway": null
-    }],
-    "receipt_is_email": false,
-    "receipt_ref": "D17200109877",
-    "claimed_at": null,
-    "receipt_email": null,
-    "staff": {
-        "id": "9b461544-f0db-44b6-b559-0f698c881229",
-        "full_name": null,
-        "email": "staff-profile-sqdzljthztvdvsjn@omneo.io",
-        "identities": [{
-            "id": 1955,
-            "handle": "staff",
-            "identifier": "73648",
-            "is_primary": false,
-            "is_active": true,
-            "profile_id": "9b461544-f0db-44b6-b559-0f698c881229",
-            "merged_from": null,
-            "created_at": "2024-02-06 20:57:48",
-            "updated_at": "2024-02-06 20:57:48"
-        }]
-    },
-    "currency_id": 2,
-    "currency_rate": 1,
-    "currency": "AUD",
-    "currency_values": [],
-    "type": null,
-    "status": null,
-    "order_number": null,
-    "order_id": null,
-    "external_order_id": null,
-    "need_action": null,
-    "custom_fields": [],
-    "timezone": "Australia\/Melbourne",
-    "transacted_at": "2024-02-13 01:09:57",
-    "created_at": "2024-02-13 04:07:46",
-    "updated_at": "2024-02-13 04:07:46"
+    transaction: {
+      transacted_at: '2024-02-13 01:09:57',
+      receipt_ref: 'D17200109877',
+      external_id: '36865285'
+    }
+  }],
+  payments: [{
+    id: '110943824',
+    web_order_number: null,
+    payment_code: 'CASH',
+    paymenttype_id: '506',
+    payment_number: null,
+    eftpos_cardtype: null,
+    tender_value: 69,
+    eftpos_stan: null,
+    eftpos_authcode: null,
+    eftpos_settlement: null,
+    eftpos_reference: null,
+    payment_ref1: null,
+    payment_ref2: null,
+    payment_ref3: null,
+    payment_gateway: null
+  }],
+  receipt_is_email: false,
+  receipt_ref: 'D17200109877',
+  claimed_at: null,
+  receipt_email: null,
+  staff: {
+    id: '9b461544-f0db-44b6-b559-0f698c881229',
+    full_name: null,
+    email: 'staff-profile-sqdzljthztvdvsjn@omneo.io',
+    identities: [{
+      id: 1955,
+      handle: 'staff',
+      identifier: '73648',
+      is_primary: false,
+      is_active: true,
+      profile_id: '9b461544-f0db-44b6-b559-0f698c881229',
+      merged_from: null,
+      created_at: '2024-02-06 20:57:48',
+      updated_at: '2024-02-06 20:57:48'
+    }]
+  },
+  currency_id: 2,
+  currency_rate: 1,
+  currency: 'AUD',
+  currency_values: [],
+  type: null,
+  status: null,
+  order_number: null,
+  order_id: null,
+  external_order_id: null,
+  need_action: null,
+  custom_fields: [],
+  timezone: 'Australia/Melbourne',
+  transacted_at: '2024-02-13 01:09:57',
+  created_at: '2024-02-13 04:07:46',
+  updated_at: '2024-02-13 04:07:46'
 }
 
-export default readTransaction;
+export default readTransaction

--- a/src/tests/mocks/transactions/transaction.ts
+++ b/src/tests/mocks/transactions/transaction.ts
@@ -1,0 +1,188 @@
+import {Transaction, TransactionInput} from "../../../types";
+
+export const writeTransaction: TransactionInput = {
+    "profile_id": "9d7796e5-f8a0-4611-aa61-e6872a6a4393",
+    "external_id": "9999999",
+    "receipt_ref": "D172009999999",
+    "location_id": "49",
+    "total": 100,
+    "total_original": 100,
+    "systems": [
+        "CI"
+    ],
+    "tags": [
+        "ci",
+        "test"
+    ],
+    "items": [{
+        "name": "GH ACTION TEST ITEM",
+        "quantity": 1,
+        "price_current": 100,
+        "price_sell": 100,
+        "price_tax": 10,
+        "price_original": 100,
+        "product_variant": {
+            "product_id": 1981205,
+            "sku": "gh-test-action-item-1",
+            "barcode": "GHT-0001",
+            "title": "GH ACTION TEST ITEM 1",
+            "brand": "Omneo",
+            "category": "Testing",
+            "price": 100
+        },
+        "discounts": []
+    }],
+    "payments": [],
+    "timezone": "Australia\/Melbourne",
+    "transacted_at": "2024-11-11 12:00:00",
+    "meta": {
+        "test": "test"
+    }
+}
+
+export const readTransaction: Transaction = {
+    "id": 9999999,
+    "external_id": "9999999",
+    "redemption": null,
+    "profile_id": "9a690c37-5bec-44f4-b6b3-8cbe11e46276",
+    "profile": {
+        "email": "subscriptions+githubactions@arkade.com.au"
+    },
+    "location": {
+        "id": 49,
+        "type": null,
+        "name": null,
+        "description": null,
+        "phone": null,
+        "email": null,
+        "external_id": "GH-ACTIONS",
+        "is_published": false,
+        "is_permanently_closed": false,
+        "address": null
+    },
+    "meta": {
+        "web_order_number": null
+    },
+    "total": 69,
+    "total_original": 69,
+    "total_converted": 69,
+    "systems": [
+        "CI"
+    ],
+    "rounding": null,
+    "margin": 43,
+    "is_void": false,
+    "tags": [],
+    "items": [{
+        "id": 2542,
+        "external_id": null,
+        "name": "GH ACTION TEST ITEM",
+        "transaction_id": 7479194,
+        "product_id": 227266,
+        "product_variant_id": 227266,
+        "sku": null,
+        "variant_external_id": null,
+        "is_void": false,
+        "quantity": 1,
+        "price_current": 100,
+        "price_sell": 100,
+        "price_original": 100,
+        "price_margin": 10,
+        "price_tax": 10,
+        "discounts": null,
+        "department": null,
+        "meta": null,
+        "product_images": [],
+        "order_id": null,
+        "created_at": "2024-02-13 04:07:46",
+        "updated_at": "2024-02-13 04:07:46",
+        "pivot": [],
+        "product_variant": {
+            "id": 227266,
+            "product_id": 227266,
+            "sku": "1299388",
+            "external_id": 227266,
+            "barcode": "",
+            "web_url": null,
+            "handle": null,
+            "title": "GH ACTION TEST ITEM",
+            "description": null,
+            "position": 1,
+            "price": 100,
+            "price_discounted": null,
+            "price_comparison": null,
+            "price_cost": null,
+            "available_quantity": null,
+            "images": [],
+            "meta": null,
+            "tags": [],
+            "options": [],
+            "created_at": "2024-02-06 20:57:48",
+            "updated_at": "2024-02-06 20:57:48"
+        },
+        "product": {
+            "title": "GH ACTION TEST ITEM",
+            "department": null,
+            "brand": "Omneo"
+        },
+        "transaction": {
+            "transacted_at": "2024-02-13 01:09:57",
+            "receipt_ref": "D17200109877",
+            "external_id": "36865285"
+        }
+    }],
+    "payments": [{
+        "id": "110943824",
+        "web_order_number": null,
+        "payment_code": "CASH",
+        "paymenttype_id": "506",
+        "payment_number": null,
+        "eftpos_cardtype": null,
+        "tender_value": 69,
+        "eftpos_stan": null,
+        "eftpos_authcode": null,
+        "eftpos_settlement": null,
+        "eftpos_reference": null,
+        "payment_ref1": null,
+        "payment_ref2": null,
+        "payment_ref3": null,
+        "payment_gateway": null
+    }],
+    "receipt_is_email": false,
+    "receipt_ref": "D17200109877",
+    "claimed_at": null,
+    "receipt_email": null,
+    "staff": {
+        "id": "9b461544-f0db-44b6-b559-0f698c881229",
+        "full_name": null,
+        "email": "staff-profile-sqdzljthztvdvsjn@omneo.io",
+        "identities": [{
+            "id": 1955,
+            "handle": "staff",
+            "identifier": "73648",
+            "is_primary": false,
+            "is_active": true,
+            "profile_id": "9b461544-f0db-44b6-b559-0f698c881229",
+            "merged_from": null,
+            "created_at": "2024-02-06 20:57:48",
+            "updated_at": "2024-02-06 20:57:48"
+        }]
+    },
+    "currency_id": 2,
+    "currency_rate": 1,
+    "currency": "AUD",
+    "currency_values": [],
+    "type": null,
+    "status": null,
+    "order_number": null,
+    "order_id": null,
+    "external_order_id": null,
+    "need_action": null,
+    "custom_fields": [],
+    "timezone": "Australia\/Melbourne",
+    "transacted_at": "2024-02-13 01:09:57",
+    "created_at": "2024-02-13 04:07:46",
+    "updated_at": "2024-02-13 04:07:46"
+}
+
+export default readTransaction;

--- a/src/tests/mocks/transactions/transaction.ts
+++ b/src/tests/mocks/transactions/transaction.ts
@@ -1,10 +1,10 @@
 import { Transaction, TransactionInput } from '../../../types'
 
-export const writeTransaction: TransactionInput = {
-  profile_id: '9d7796e5-f8a0-4611-aa61-e6872a6a4393',
+export const writeTransactionWithVariant: TransactionInput = {
+  profile_id: process.env.OMNEO_TEST_PROFILE_ID,
   external_id: '9999999',
   receipt_ref: 'D172009999999',
-  location_id: '49',
+  location_id: process.env.OMNEO_TEST_LOCATION_ID,
   total: 100,
   total_original: 100,
   systems: [
@@ -22,7 +22,7 @@ export const writeTransaction: TransactionInput = {
     price_tax: 10,
     price_original: 100,
     product_variant: {
-      product_id: 1981205,
+      product_id: parseInt(process.env.OMNEO_TEST_PRODUCT_ID),
       sku: 'gh-test-action-item-1',
       barcode: 'GHT-0001',
       title: 'GH ACTION TEST ITEM 1',
@@ -40,16 +40,48 @@ export const writeTransaction: TransactionInput = {
   }
 }
 
+export const writeTransactionWithVariantID: TransactionInput = {
+  profile_id: process.env.OMNEO_TEST_PROFILE_ID,
+  external_id: '9999999',
+  receipt_ref: 'D1729859045',
+  location_id: process.env.OMNEO_TEST_LOCATION_ID,
+  total: 100,
+  total_original: 100,
+  systems: [
+    'CI'
+  ],
+  tags: [
+    'ci',
+    'test'
+  ],
+  items: [{
+    name: 'GH ACTION TEST ITEM',
+    quantity: 1,
+    price_current: 100,
+    price_sell: 100,
+    price_tax: 10,
+    price_original: 100,
+    product_variant_id: parseInt(process.env.OMNEO_TEST_PRODUCT_VARIANT_ID),
+    discounts: []
+  }],
+  payments: [],
+  timezone: 'Australia/Melbourne',
+  transacted_at: '2024-11-11 12:00:00',
+  meta: {
+    test: 'test'
+  }
+}
+
 export const readTransaction: Transaction = {
   id: 9999999,
   external_id: '9999999',
   redemption: null,
-  profile_id: '9a690c37-5bec-44f4-b6b3-8cbe11e46276',
+  profile_id: process.env.OMNEO_TEST_PROFILE_ID,
   profile: {
     email: 'subscriptions+githubactions@arkade.com.au'
   },
   location: {
-    id: 49,
+    id: 1,
     type: null,
     name: null,
     description: null,
@@ -63,23 +95,23 @@ export const readTransaction: Transaction = {
   meta: {
     web_order_number: null
   },
-  total: 69,
-  total_original: 69,
-  total_converted: 69,
+  total: 100,
+  total_original: 100,
+  total_converted: 100,
   systems: [
     'CI'
   ],
   rounding: null,
-  margin: 43,
+  margin: 50,
   is_void: false,
   tags: [],
   items: [{
-    id: 2542,
+    id: 1,
     external_id: null,
     name: 'GH ACTION TEST ITEM',
-    transaction_id: 7479194,
-    product_id: 227266,
-    product_variant_id: 227266,
+    transaction_id: 111111111,
+    product_id: 1,
+    product_variant_id: 1,
     sku: null,
     variant_external_id: null,
     is_void: false,
@@ -98,10 +130,10 @@ export const readTransaction: Transaction = {
     updated_at: '2024-02-13 04:07:46',
     pivot: [],
     product_variant: {
-      id: 227266,
-      product_id: 227266,
+      id: 1,
+      product_id: 1,
       sku: '1299388',
-      external_id: 227266,
+      external_id: 1111,
       barcode: '',
       web_url: null,
       handle: null,
@@ -157,12 +189,12 @@ export const readTransaction: Transaction = {
     full_name: null,
     email: 'staff-profile-sqdzljthztvdvsjn@omneo.io',
     identities: [{
-      id: 1955,
+      id: 1,
       handle: 'staff',
       identifier: '73648',
       is_primary: false,
       is_active: true,
-      profile_id: '9b461544-f0db-44b6-b559-0f698c881229',
+      profile_id: '9b461544-f0db-44b6-b559-0f698c881555',
       merged_from: null,
       created_at: '2024-02-06 20:57:48',
       updated_at: '2024-02-06 20:57:48'

--- a/src/types/identities.ts
+++ b/src/types/identities.ts
@@ -1,13 +1,13 @@
 export type Identity = {
-  id: string
+  id: number
   merged_from: string | null
   profile_id: string
   is_primary: boolean
   is_active: boolean
   identifier: string
   handle: string
-  created_at: Date
-  updated_at: Date
+  created_at: string
+  updated_at: string
 }
 
 export type IdentityRequest = {

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -30,12 +30,12 @@ export type Location = {
   description: string | null
   phone: string | null
   email: string
-  timezone: string
+  timezone?: string
   external_id: string
-  external_code: string
+  external_code?: string
   is_published: boolean
   is_permanently_closed: boolean
-  address: Address
-  normal_hours: Array<NormalHour>
-  special_hours: Array<SpecialHour>
+  address: Address | null
+  normal_hours?: Array<NormalHour>
+  special_hours?: Array<SpecialHour>
 }

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,0 +1,19 @@
+export type PaymentCode = "CASH"
+
+export type Payment = {
+  id: string
+  web_order_number: number | null
+  payment_code: PaymentCode | string
+  paymenttype_id: string
+  payment_number: string | null
+  eftpos_cardtype: string | null
+  tender_value: number
+  eftpos_stan: string | null
+  eftpos_authcode: string | null
+  eftpos_settlement: string | null
+  eftpos_reference: string | null
+  payment_ref1: string | null
+  payment_ref2: string | null
+  payment_ref3: string | null
+  payment_gateway: string | null
+}

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,4 +1,4 @@
-export type PaymentCode = "CASH"
+export type PaymentCode = 'CASH'
 
 export type Payment = {
   id: string

--- a/src/types/productVariant.ts
+++ b/src/types/productVariant.ts
@@ -1,0 +1,23 @@
+export type ProductVariant = {
+    id: number
+    product_id: number
+    sku: string
+    external_id: string | null
+    barcode: string | null
+    web_url: string | null
+    handle: string | null
+    title: string
+    description: string | null
+    position: number
+    price: number
+    price_discounted: number | null
+    price_comparison: number | null
+    price_cost: number | null
+    available_quantity: number | null
+    images: Array<any>
+    meta: { [key: string]: any } | null
+    tags: Array<string>
+    options: Array<any>
+    created_at: string
+    updated_at: string
+}

--- a/src/types/productVariant.ts
+++ b/src/types/productVariant.ts
@@ -2,7 +2,7 @@ export type ProductVariant = {
     id: number
     product_id: number
     sku: string
-    external_id: string | null
+    external_id: number | null
     barcode: string | null
     web_url: string | null
     handle: string | null

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,8 +1,8 @@
 import { Identity } from './identities'
 import { Location } from './location'
-import {Redemption} from "./redemption";
-import {Payment} from "./payment";
-import {ProductVariant} from "./productVariant";
+import { Redemption } from './redemption'
+import { Payment } from './payment'
+import { ProductVariant } from './productVariant'
 
 export type TransactionFilters = 'profile_id' | 'total' | 'rounding' | 'total_original' | 'margin' | 'external_id' | 'deliver_at' | 'transacted_at' | 'timezone' | 'receipt_is_email' | 'receipt_ref' | 'location_id' | 'systems.handle' | 'type' | 'status' | 'order_number' | 'tags.handle' | 'location.name' | 'profile.identities.identifier' | 'need_action'
 export type TransactionItem = {
@@ -120,7 +120,7 @@ export interface TransactionLineItemInput {
   discounts?: TransactionLineItemDiscount[];
 }
 
-export type TransactionInput =  {
+export type TransactionInput = {
   profile_id: string;
   external_id: string;
   receipt_ref: string;

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -92,6 +92,53 @@ export type Transaction = {
   updated_at: string
 }
 
+export type TransactionLineItemProductVariantInput = {
+  product_id: number;
+  sku: string;
+  barcode?: string;
+  title: string;
+  brand: string;
+  category: string;
+  subcategory?: string;
+  price: number;
+}
+
+export interface TransactionLineItemDiscount {
+  amount: number;
+  reason_desc: string;
+}
+
+export interface TransactionLineItemInput {
+  name: string;
+  quantity: number;
+  price_current: number;
+  price_sell: number;
+  price_tax: number;
+  price_original: number;
+  product_variant_id?: number;
+  product_variant?: TransactionLineItemProductVariantInput;
+  discounts?: TransactionLineItemDiscount[];
+}
+
+export type TransactionInput =  {
+  profile_id: string;
+  external_id: string;
+  receipt_ref: string;
+  location_id: string;
+  total: number;
+  total_original: number;
+  systems?: string[];
+  timezone: string;
+  tags: string[];
+  items: TransactionLineItemInput[];
+  payments?: any[];
+  transacted_at: string;
+  created_at?: string;
+  updated_at?: string;
+  meta?: { [key: string ] : any };
+  delete_existing_items?: boolean;
+}
+
 export type GroupedTransaction = {
   order_number: string | null
   transaction_id: number

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,5 +1,8 @@
 import { Identity } from './identities'
 import { Location } from './location'
+import {Redemption} from "./redemption";
+import {Payment} from "./payment";
+import {ProductVariant} from "./productVariant";
 
 export type TransactionFilters = 'profile_id' | 'total' | 'rounding' | 'total_original' | 'margin' | 'external_id' | 'deliver_at' | 'transacted_at' | 'timezone' | 'receipt_is_email' | 'receipt_ref' | 'location_id' | 'systems.handle' | 'type' | 'status' | 'order_number' | 'tags.handle' | 'location.name' | 'profile.identities.identifier' | 'need_action'
 export type TransactionItem = {
@@ -8,7 +11,13 @@ export type TransactionItem = {
   name: string
   transaction_id: number
   product_id: number
+  product: {
+    title: string
+    department: string | null
+    brand: string | null
+  }
   product_variant_id: number | null
+  product_variant: ProductVariant
   sku: string | null
   variant_external_id: string | null
   is_void: boolean
@@ -21,41 +30,46 @@ export type TransactionItem = {
   discounts: Array<{
     amount: number
     reason_desc: string
-  }>
+  }> | null
   department: string | null
   product_images: Array<any>
-  created_at: Date
-  updated_at: Date
+  order_id: number | null
+  created_at: string
+  updated_at: string
+  pivot: any[]
   transaction: {
-    transacted_at: Date
+    transacted_at: string
     receipt_ref: string | null
     external_id: string | null
   }
+  meta: {[key: string]: any}
 }
 
 export type Transaction = {
-  id: string
+  id: number
   external_id: string
   profile_id?: string
   profile?: {
     email: string
   }
+  redemption: Redemption | null
   location?: Location
   meta: {[key: string]: any}
   total: number
   total_original: number | null
-  systems: Array<any>
+  total_converted: number | null
+  systems: Array<string>
   rounding: number | null
   margin: number | null
   is_void: boolean
-  transacted_at: Date
+  transacted_at: string
   timezone: string
   tags: Array<string>
   items: Array<TransactionItem>
-  payments: Array<string>
+  payments: Array<Payment>
   receipt_is_email: boolean
   receipt_ref: string | null
-  claimed_at: Date | null
+  claimed_at: string | null
   receipt_email: string | null
   staff: {
     id: string
@@ -63,11 +77,19 @@ export type Transaction = {
     email: string
     identities: Array<Identity>
   } | null
-  currency_id: string | null
+  currency_id: number | null
   currency_rate: number | null
   currency: string | null
-  created_at: Date
-  updated_at: Date
+  currency_values: any[]
+  type: string | null
+  status: string | null
+  order_number: string | null
+  order_id: string | null
+  external_order_id: string | null
+  need_action: boolean | null
+  custom_fields: { [key: string]: any }
+  created_at: string
+  updated_at: string
 }
 
 export type GroupedTransaction = {

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -137,6 +137,7 @@ export type TransactionInput = {
   updated_at?: string;
   meta?: { [key: string ] : any };
   delete_existing_items?: boolean;
+  receipt_is_email?: boolean;
 }
 
 export type GroupedTransaction = {

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -138,6 +138,7 @@ export type TransactionInput = {
   meta?: { [key: string ] : any };
   delete_existing_items?: boolean;
   receipt_is_email?: boolean;
+  is_void?: boolean | null;
 }
 
 export type GroupedTransaction = {


### PR DESCRIPTION
# Summary :

Adds TXN update-create method to transactions class.

* Changes the transaction types to match an actual response from the API.
* Adds additional Payment type which is used within Transaction type.
* Adds additional ProductVariant type which is used within Transaction type.

## Tests :

* Initialises vitest set up.
* Adds mocks for transactions.
* Add simple fetch client for facilitating test requests.
* Adds transaction create test.
* Adds transaction update test.

## Workflows :

* Adds workflow for test suite.


## Notes:

While testing I found that `receipt_is_email` and `is_void` transaction attributes are required on update, but not create. This is a bit unintuitive and might mean we need separate input types for create vs update. Is that expected? 