### PR TITLE
feat: added appointments endpoints for both ID and omneo clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,351 @@
+# AGENTS.md — omneo-sdk
+
+Guidance for AI agents (and new contributors) working in this repository. It is
+prescriptive: where the existing code is inconsistent, this file states the
+canonical style for **new** code. Match older variants only when editing inside
+a file that already uses them.
+
+## Project overview
+
+`@omneo/omneo-sdk` is a zero-runtime-dependency TypeScript SDK for the Omneo
+platform. It relies on global `fetch`/`Headers` (Node >= 20) — no axios, no
+HTTP wrapper library. Built with tsup to CJS + ESM + declaration files.
+
+The public API surface is exactly three things, exported from `src/index.ts`:
+
+```ts
+export * from './types'
+export { Omneo } from './omneo'
+export { ID } from './id'
+```
+
+Two client classes, one package:
+
+| Client | File | Base URL | Auth | Scope |
+|---|---|---|---|---|
+| `Omneo` | `src/omneo/index.ts` | `https://api.${tenant}.getomneo.com/api/v3` | long-lived bearer `token` | Admin/server API — ~58 resources covering the whole platform |
+| `ID` | `src/id/index.ts` | `https://api.${tenant}.getomneo.com/id/api/v1` | short-lived per-profile `IDToken` | Customer-facing API — `auth` + `profile`, where `profile` mirrors the admin `profiles` sub-resource tree with every endpoint under `/profiles/me` (no profile id arguments) |
+
+Individual resource classes are **not** exported publicly — they are reachable
+only as instance properties (`omneo.brands.get(1)`). Both clients expose
+`call({ method, endpoint, params?, body?, headers? })` as the escape hatch for
+unsupported endpoints.
+
+## Repository map
+
+| Path | Purpose |
+|---|---|
+| `src/omneo/resources/<kebab-name>/index.ts` | Admin resources (some with nested sub-resource dirs) |
+| `src/omneo/resources/resource.ts` | Thin base `Resource` class (holds `client: Omneo`) |
+| `src/id/resources/{auth,profile}/…` | ID resources; `profile` has ~25 sub-resources |
+| `src/id/resources/resource.ts` | Base `IDResource` class |
+| `src/types/` | All shared types, one kebab-case file per domain, barrel at `src/types/index.ts` |
+| `src/tests/integration/{omneo,id}/` | Vitest integration tests (live API — see Testing) |
+| `src/tests/lib/` | Test helpers, imported as `@lib` |
+| `src/tests/mocks/` | Static fixture data (NOT HTTP mocks, despite the name) |
+| `sample/sample.ts` | Dev scratchpad for hitting the SDK manually |
+| `dist/` | Build output (gitignored) |
+
+Path aliases (`@/*`, `@omneo`, `@id`, `@types`, `@lib`) are declared in **both**
+`tsconfig.json` `paths` and `vitest.config.ts` `resolve.alias` — if you add or
+change one, keep the two in sync.
+
+## Commands
+
+| Goal | Command | Notes |
+|---|---|---|
+| Build | `npm run build` | tsup CJS+ESM+dts; config lives entirely in the script flags — there is no `tsup.config.ts` |
+| Build watch | `npm run watch` | This watches the **build**, not tests |
+| Lint | `npm run lint` | ESLint is the only formatter — no prettier/biome/editorconfig |
+| Lint + fix | `npm run lint-fix` | |
+| Targeted tests | `npx vitest run <file-or-dir>` | The only safe way to run tests — see Testing |
+| Full test suite | `npm test` | ⚠️ Fires ~262 live-API test files at the tenant in `.env`. **Do not run unless explicitly asked.** |
+| Sample scratchpad | `npm run sample` | Requires `tsx`, which is currently not in devDependencies |
+
+There is no typecheck script; the closest is `npm run build` (tsup emits
+declarations). The `eslint` script (`eslint index.ts`) targets a nonexistent
+file — use `lint`/`lint-fix`.
+
+## Architecture and the resource pattern
+
+### Composition
+
+The client classes are the composition root. Every resource is instantiated as
+a `public` class property: `public camelCasePlural = new PascalClass(this)`.
+The property list in `Omneo` is **alphabetised with blank lines grouping letter
+runs** — a new resource must slot into its alphabetical position. (`health` is
+the one function-style exception: `public health = health.bind(this)`.)
+
+Sub-resources are composed the same way one level down, receiving
+`this.client`:
+
+```ts
+export default class Transactions extends Resource {
+  customFields = new TransactionCustomFields(this.client)
+  items = new TransactionItems(this.client)
+}
+```
+
+The base classes are trivially thin — no shared HTTP helpers. All requests go
+through `this.client.call(...)`.
+
+### Canonical resource shape
+
+`src/omneo/resources/brands/index.ts` is the cleanest exemplar of the shape.
+The canonical template for a **new** resource (uppercase HTTP methods — see
+Code style):
+
+```ts
+import { RequestParams, Brand, BrandInput, BrandResponse } from '@types'
+import Resource from '../resource.js'
+
+export default class Brands extends Resource {
+  get (id: number, params?: RequestParams): Promise<Brand> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/brands/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (params?: RequestParams): Promise<BrandResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/brands',
+      params
+    })
+  }
+
+  create (body: BrandInput): Promise<Brand> { /* POST, unwrap .data */ }
+  update (id: number, body: Partial<BrandInput>): Promise<Brand> { /* PUT, unwrap .data */ }
+  delete (id: number): Promise<void> { /* DELETE, no unwrap */ }
+}
+```
+
+Rules encoded in that shape:
+
+- `export default class X extends Resource`, PascalCase pluralised class name,
+  no constructor of its own. Sub-resource classes are prefixed with their
+  parent scope (`TransactionItems`, `ProfileAttributesCustom`).
+- Method names: `get` / `list` / `create` / `update` / `delete`; non-CRUD
+  actions get camelCase verbs (`resync`, `merge`, `findByEmail`,
+  `checkAvailability`, `triggerCustomEvent`).
+- Signature order: path ids first, then `body`, then `params?` (always typed
+  `RequestParams`).
+- `get`/`create`/`update` unwrap the envelope with
+  `.then((response) => { return response.data })` — explicit block body with
+  `return`, not a concise arrow.
+- `list` returns the **full envelope** (`EntityResponse` = pagination links,
+  meta and `data`) and never unwraps. Non-paginated list endpoints return
+  `Promise<Entity[]>` and unwrap, with a `// Not Paginated` comment.
+- Update payloads are `Partial<XInput>` unless a dedicated `UpdateXInput`
+  exists.
+- Composite custom-field keys are built as a named local on its own line:
+  `` const attribute = `${namespace}:${handle}` ``.
+- Pagination is manual/pass-through: callers supply `page[size]` /
+  `page[number]` and Laravel-style bracket filters (`'filter[email]': email`)
+  in `params`. There is no auto-paginating iterator — do not add one to a
+  single resource ad hoc.
+
+### The ID mirror rule
+
+A change to an admin resource almost always needs a mirrored change in
+`src/id/resources/profile/<same-name>/index.ts` — same shape, minus the
+profile id arguments (everything is `/profiles/me/...`). Mirror the READMEs
+and tests too (see the checklist below).
+
+### File and directory naming
+
+- Resource directories: kebab-case, pluralised, matching the API path segment
+  (`achievement-definitions`, `custom-fields`).
+- Every resource implementation is `index.ts` inside its own directory —
+  resource dirs are not barrels; `index.ts` *is* the implementation.
+- Imports: types always `from '@types'`; base class `from '../resource.js'`
+  (with the `.js` extension, correct for `nodenext` resolution) — except
+  inside the deep `profiles`/`profile` trees, where the local norm is the
+  alias form (`'@omneo/resources/resource'` / `'@id/resources/resource'`).
+
+## Types (`src/types/`)
+
+- One kebab-case file per domain; every new file must be added to the barrel
+  `src/types/index.ts` (a flat list of `export * from './x'` lines).
+- **Use `type` aliases, never `interface`** (369 `export type` vs 2 legacy
+  interfaces in the codebase).
+- Naming triad per entity, modelled on `src/types/brands.ts`:
+  - `Entity` — the API resource shape, snake_case fields matching the API
+    verbatim, nullability spelled out explicitly (`external_id: string | null`).
+  - `EntityInput` — derived from the entity, not hand-written:
+    `Partial<Omit<Entity, 'id' | 'created_at' | 'updated_at'>> & { handle: Entity['handle'] }`.
+    Use `CreateEntityInput`/`UpdateEntityInput` only when create and update
+    genuinely differ.
+  - `EntityResponse` — always `PaginationResponse & { data: Entity[] }`.
+- Enums are inline string-literal unions, extracted to a named type when
+  reused (`export type ProfileType = 'temporary' | 'dependant' | …`).
+- Open-ended blobs are `{ [key: string]: any }` (the codebase never uses
+  `Record<string, unknown>`); `meta` objects list known keys plus an index
+  signature.
+- **No generics anywhere.** `client.call` returns `Promise<any>`; each
+  resource method annotates its own concrete return type. Follow that —
+  don't introduce a generic `call<T>`.
+
+## Code style
+
+ESLint extends `eslint-config-standard` (JS Standard Style) with zero rule
+overrides. There is no prettier. In practice:
+
+- Single quotes; template literals for interpolation.
+- **No semicolons.**
+- 2-space indent; no trailing commas; `===`; object literals broken one
+  property per line.
+- **Space before function parens** — `get (id: number, params?: RequestParams)`,
+  `constructor (options: OmneoClassOptions)`. This is the easiest rule to get
+  wrong when writing TypeScript from muscle memory.
+- **Promise chains, not async/await, inside resource methods.** There are zero
+  `async` resource methods; `async/await` appears only in the clients' `call`
+  implementations, standalone helpers, and test files.
+- Conditional spread for optional request fields:
+  `...(body && { body: JSON.stringify(body) })`.
+- `Promise.reject(new Error(...))` for failures in async paths;
+  `throw Error(...)` in sync helpers.
+- **No JSDoc.** Method documentation lives in the per-resource `README.md`
+  (see below). Inline `//` comments are reserved for API quirks
+  (`// Omneo API bug cannot accept null`, `// Not Paginated`).
+
+Canonical choices where existing code is split — use these in new code:
+
+| Topic | Canonical | Legacy variants you'll see |
+|---|---|---|
+| HTTP method strings | `'GET'` / `'POST'` / `'PUT'` / `'DELETE'` (uppercase) | lowercase `'get'` etc. (~50% of older code) |
+| Base `Resource` import | `'../resource.js'` (or the alias form inside the profiles trees) | extensionless `'../resource'` |
+| `list()` return | full envelope, no unwrap | a few files unwrap `.data` |
+| Boolean type | lowercase `boolean` | boxed `Boolean` in a few option/return spots |
+
+## Testing
+
+> ⚠️ **Every test in this repo is a live integration test.** All ~262
+> `*.test.ts` files create, update and delete real data against the tenant in
+> `.env` over the network. There is no HTTP mocking anywhere (`src/tests/mocks/`
+> is static fixture data, not mocks). Commit messages calling them "unit tests"
+> are a misnomer.
+>
+> **Run only the test files relevant to your change**, e.g.
+> `npx vitest run src/tests/integration/omneo/tier-definitions/`.
+> Never run `npm test` (the full suite) unless the user explicitly asks.
+
+- Framework: Vitest, globals **off** — every file imports what it uses:
+  `import { describe, expect, test, afterAll } from 'vitest'`. Use `test()`
+  exclusively; `it()` appears nowhere.
+- Layout mirrors the resource tree: `src/tests/integration/omneo/<resource>/`
+  and `src/tests/integration/id/profile/<resource>/`, one file per operation,
+  named `<verb>-<resource>.test.ts` (prefixed `id-` in the id tree). Always
+  `.test.ts`, never `.spec.ts`.
+- Anatomy of a test (see
+  `src/tests/integration/omneo/tier-definitions/create-tier-definition.test.ts`):
+  1. Module-scope client:
+     `new Omneo({ tenant: process.env.OMNEO_TENANT as string, token: process.env.OMNEO_TOKEN as string })`.
+  2. SCREAMING_SNAKE tracking array for teardown:
+     `const CREATED_TIER_DEFINITION_IDS: number[] = []`.
+  3. `describe('<Human Phrase>')`; test names start `'SDK ...'` (or
+     `'ID SDK ...'` in the id tree).
+  4. Unique payload values via `getRandomString('sdk_unit_test_...')` from `@lib`.
+  5. SDK call with the log-and-rethrow idiom:
+     `.catch((err) => { console.error('... failed:', err); throw new Error('... failed') })`.
+  6. Flat round-trip assertions: `expect(x).toBeDefined()` then
+     `expect(x.field).toBe(payload.field)` per field; `toHaveProperty` for
+     shape-only checks.
+  7. `afterAll` **outside** the `describe`, deleting tracked ids via the raw
+     `simpleOmneoRequest('DELETE', ...)` helper — deliberately bypassing the
+     SDK so cleanup can't be masked by SDK bugs — logging (not asserting) the
+     outcome.
+- ID-tree tests use the `testWithIDData` fixture
+  (`src/tests/integration/id/test-with-id-data.ts`), which provides
+  `{ profile, tokenData }`; construct the `ID` client inside the test with
+  `IDToken: tokenData.token`. Seed prerequisite data with the raw helpers
+  (`simpleOmneoRequest`/`simpleIDRequest`), not the SDK under test.
+- Env vars: `OMNEO_TENANT` and `OMNEO_TOKEN` (in `.env.example`), plus
+  `OMNEO_TEST_PROFILE_ID`, `OMNEO_TEST_PRODUCT_ID`,
+  `OMNEO_TEST_PRODUCT_VARIANT_ID`, `OMNEO_TEST_LOCATION_ID` used by many tests
+  but absent from `.env.example`. All `.env` vars are injected via
+  `vitest.config.ts` (`loadEnv` with no prefix filter). Test timeout is 40s.
+
+## Per-resource README convention
+
+Every resource directory ships a hand-written colocated `README.md`:
+
+- `## <Resource>` heading, one `### <Verb Resource>` section per method.
+- One ```javascript fence per method showing usage as
+  `omneoClient.<accessor>.<method>(...).then(...).catch(...)`, with 4-space
+  indent inside the fence.
+- Parent resources with children (e.g. `profiles`) carry a table of contents
+  linking to child READMEs.
+
+When you add or change a method, update the README in the same directory —
+and its mirror in the other tree if the resource is mirrored.
+
+## Adding a new resource — full checklist
+
+1. `src/omneo/resources/<kebab-name>/index.ts` — resource class per the
+   canonical shape above.
+2. Register it on the `Omneo` class as a `public camelCasePlural` property in
+   **alphabetical position**.
+3. Types triad in a new `src/types/<kebab-name>.ts`, added to the
+   `src/types/index.ts` barrel.
+4. `src/omneo/resources/<kebab-name>/README.md` per the README convention.
+5. If the resource exists on the customer surface: mirror under
+   `src/id/resources/profile/<kebab-name>/index.ts` (no id args), register it
+   on the `profile` resource, and add its README.
+6. Tests: one file per operation under `src/tests/integration/omneo/<kebab-name>/`
+   (and `src/tests/integration/id/profile/<kebab-name>/` if mirrored), with
+   `afterAll` cleanup.
+
+## Git, CI and release
+
+- **Angular conventional commits, enforced** by the husky `commit-msg` hook +
+  commitlint. Allowed types: `build, ci, docs, feat, fix, perf, refactor,
+  revert, style, test, chore`. Header ≤ 72 chars. Scopes are unused in
+  practice (`feat: add integration tests for profile tiers`).
+- Branches: feature branches `feat/<kebab-slug>` / `fix/<kebab-slug>` PR into
+  `develop`; `develop` is promoted to `master`, which triggers
+  **semantic-release** (publish to npm, GitHub release, CHANGELOG commit).
+- **Never hand-edit `package.json` `version` or `CHANGELOG.md`** — both are
+  machine-owned by semantic-release on `master`.
+- CI: `lint.yml` runs `npm run lint` on every PR; `test.yml` runs the full
+  live suite (Node 20, repo secrets) on pushes to non-master branches and PRs
+  into master. There are no pre-commit/pre-push hooks — only `commit-msg`.
+- Merge style: GitHub merge commits (not squash/rebase).
+
+## Known issues — do not replicate, do not "fix" unprompted
+
+These exist in the codebase today. Don't copy them into new code; don't fix
+them as a drive-by either — they may have downstream consumers relying on
+current behaviour. Raise them separately if relevant.
+
+- **Error-shape asymmetry**: `Omneo.call` rejects with the parsed response
+  body; `ID.call` rejects with the raw `Response`. Callers probe defensively
+  (`error?.errors || error?.body?.errors`).
+- `ID.call` ignores the `headers` field of `OmneoRequest` (only `Omneo.call`
+  merges custom headers).
+- `OmneoProfile.Connection(connectionID)` monkey-patches `call` on the
+  **shared** client instance, leaking the endpoint rewrite onto the original.
+- Naming slips: `Omneo.saveFilters` (should be `savedFilters`),
+  `Currency` class on the `currencies` property, singular `reminder/` dir for
+  `Reminders`, `ID.profile` exports `class OmneoProfile`.
+- Wrong/placeholder annotations: `ProfileAttributesCustom.delete` typed
+  `Promise<Response>` (id-side `Promise<Address>`); `TransactionItems.list`
+  hits a literal un-substituted `'/transactions/:transactionsId/items'`;
+  `ProfileTransactions.getGrouped` spreads `page[...]` params onto the request
+  root where they're silently dropped.
+- Boxed `Boolean` type in a few option/return positions.
+- `package.json` has `"engine"` (singular — inert; npm's field is `engines`),
+  an empty `description`, `@types/node` (v18) in runtime `dependencies`, and
+  no `exports` map despite emitting `.mjs`.
+- `Resource.init?()` is a dead extension point — no resource implements it.
+- `src/types/general.ts` and `src/types/payment.ts` are missing from the types
+  barrel (publicly unreachable).
+- A few type files leak semicolons/4-space indent (`webhooks.ts`, parts of
+  `transaction.ts`, `achievement.ts`).
+- Some tests mutate `process.env.TZ` in `beforeAll` — a cross-file race under
+  Vitest's parallel execution; another reason to run tests targeted, not all
+  at once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+All repository guidance lives in @AGENTS.md — architecture, resource patterns, code style, git/release rules, and testing.
+
+⚠️ Critical: every test in this repo is a live integration test against a real tenant. Run targeted files only (`npx vitest run <path>`) — never `npm test` unless explicitly asked. Details in AGENTS.md.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11343,20 +11343,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -19843,14 +19829,6 @@
             "tr46": "^1.0.1",
             "webidl-conversions": "^4.0.2"
           }
-        },
-        "yaml": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-          "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },

--- a/src/id/resources/profile/appointments/README.md
+++ b/src/id/resources/profile/appointments/README.md
@@ -1,0 +1,99 @@
+## Profile Appointments
+
+Manage the signed-in customer's appointments through the ID API. All routes are scoped to `/profiles/me`, so no profile ID is needed.
+
+### Get Appointment
+
+Retrieves one of the customer's appointments by ID.
+
+```javascript
+IDClient.profile.appointments.get(5012)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Appointments
+
+Retrieves the customer's appointments. Pass `filter[status]` to narrow the results.
+
+```javascript
+const params = {
+    'filter[status]': 'confirmed'
+}
+
+IDClient.profile.appointments.list(params)
+    .then((appointments) => {
+        console.log(appointments)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment
+
+Books an appointment for the customer. Times are sent in the request `timezone` and stored in UTC.
+
+```javascript
+const payload = {
+    appointment_definition_id: 1,
+    location_id: 13,
+    scheduled_start_at: '2026-05-11 10:00:00',
+    scheduled_end_at: '2026-05-11 10:30:00',
+    timezone: 'Australia/Melbourne'
+}
+
+IDClient.profile.appointments.create(payload)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment
+
+Updates or reschedules one of the customer's appointments, for example cancelling it.
+
+```javascript
+IDClient.profile.appointments.update(5012, { status: 'cancelled' })
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment
+
+Deletes one of the customer's appointments.
+
+```javascript
+IDClient.profile.appointments.delete(5012)
+    .then(() => {
+        console.log('appointment deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Visible Appointment Definitions
+
+Retrieves the published, non-archived appointment definitions visible to the customer, for rendering a booking flow.
+
+```javascript
+IDClient.profile.appointments.listVisibleDefinitions()
+    .then((definitions) => {
+        console.log(definitions)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/id/resources/profile/appointments/index.ts
+++ b/src/id/resources/profile/appointments/index.ts
@@ -1,0 +1,57 @@
+import { RequestParams, Appointment, AppointmentResponse, AppointmentDefinitionResponse, CreateProfileAppointmentInput, UpdateAppointmentInput } from '@types'
+import Resource from '@id/resources/resource'
+
+export default class ProfileAppointments extends Resource {
+  get (appointmentID: number, params?: RequestParams): Promise<Appointment> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/me/appointments/${appointmentID}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (params?: RequestParams): Promise<AppointmentResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/profiles/me/appointments',
+      params
+    })
+  }
+
+  create (body: CreateProfileAppointmentInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: '/profiles/me/appointments',
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (appointmentID: number, body: UpdateAppointmentInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/profiles/me/appointments/${appointmentID}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (appointmentID: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/profiles/me/appointments/${appointmentID}`
+    })
+  }
+
+  listVisibleDefinitions (params?: RequestParams): Promise<AppointmentDefinitionResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/profiles/me/appointment-definitions/visibility',
+      params
+    })
+  }
+}

--- a/src/id/resources/profile/index.ts
+++ b/src/id/resources/profile/index.ts
@@ -10,6 +10,7 @@ import {
 
 import ProfileAddresses from './addresses'
 import ProfileAggregations from './aggregations'
+import ProfileAppointments from './appointments'
 import ProfileAttributesAppearance from './attributes/appearance'
 import ProfileAttributesComms from './attributes/comms'
 import ProfileAttributesCustom from './attributes/custom'
@@ -35,6 +36,7 @@ import Resource from '../resource'
 export default class OmneoProfile extends Resource {
   addresses = new ProfileAddresses(this.client)
   aggregations = new ProfileAggregations(this.client)
+  appointments = new ProfileAppointments(this.client)
   attributes = {
     custom: new ProfileAttributesCustom(this.client),
     dates: new ProfileAttributesDates(this.client),

--- a/src/omneo/index.ts
+++ b/src/omneo/index.ts
@@ -57,6 +57,10 @@ import Batches from './resources/batches'
 import Automations from './resources/automations'
 import Allocations from './resources/allocations'
 import ActionHistories from './resources/action-histories'
+import Appointments from './resources/appointments'
+import AppointmentDefinitions from './resources/appointment-definitions'
+import AppointmentQueues from './resources/appointment-queues'
+import AppointmentWaitlists from './resources/appointment-waitlists'
 export class Omneo {
   tenant: string
   token: string
@@ -75,6 +79,10 @@ export class Omneo {
   public achievementDefinitions = new AchievementDefinitions(this)
   public actionHistories = new ActionHistories(this)
   public allocations = new Allocations(this)
+  public appointmentDefinitions = new AppointmentDefinitions(this)
+  public appointmentQueues = new AppointmentQueues(this)
+  public appointmentWaitlists = new AppointmentWaitlists(this)
+  public appointments = new Appointments(this)
   public audits = new Audits(this)
   public auth = new Auth(this)
   public automations = new Automations(this)

--- a/src/omneo/resources/appointment-definitions/README.md
+++ b/src/omneo/resources/appointment-definitions/README.md
@@ -1,0 +1,177 @@
+## Appointment Definitions
+
+Manage appointment definitions, the bookable services behind appointments: duration, booking type, opening hours, locations, staff, capacity, booking questionnaires, notifications and visibility.
+
+Nested resources:
+
+- [Locations](./locations/README.md)
+- [Normal Hours](./normal-hours/README.md)
+- [Special Hours](./special-hours/README.md)
+- [Staff](./staff/README.md)
+
+### Get Appointment Definition
+
+Retrieves a specific appointment definition by ID, including its loaded `normal_hours`, `special_hours`, `locations`, `staff` and `booking_questionnaire` relations.
+
+```javascript
+omneoClient.appointmentDefinitions.get(1)
+    .then((definition) => {
+        console.log(definition)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Appointment Definitions
+
+Retrieves a list of all appointment definitions. Customer-facing lists usually filter `filter[is_published]=1&filter[is_archived]=0`.
+
+```javascript
+const params = {
+    'filter[is_published]': 1,
+    'filter[is_archived]': 0
+}
+
+omneoClient.appointmentDefinitions.list(params)
+    .then((definitions) => {
+        console.log(definitions)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Definition
+
+Creates a new appointment definition. Only `handle`, `name`, `duration_minutes` and `booking_type` (`instant`, `approval_required` or `walk_in_only`) are required. Opening hours, locations and staff can be attached inline or through the nested resources later.
+
+```javascript
+const payload = {
+    handle: 'bra-fitting',
+    name: 'Bra fitting',
+    duration_minutes: 30,
+    booking_type: 'approval_required',
+    requires_staff: true,
+    use_staff_from_location: true,
+    location_ids: [13],
+    normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+    ],
+    is_published: false
+}
+
+omneoClient.appointmentDefinitions.create(payload)
+    .then((definition) => {
+        console.log(definition)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Definition
+
+Updates an existing appointment definition by ID, for example to publish it or attach notification targets.
+
+```javascript
+const payload = {
+    is_published: true,
+    reminder_target_id: 43,
+    notify_reminder_offset_days: 1
+}
+
+omneoClient.appointmentDefinitions.update(1, payload)
+    .then((definition) => {
+        console.log(definition)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Definition
+
+Deletes an appointment definition by ID. To retire a definition while keeping its history, set `is_archived: true` instead.
+
+```javascript
+omneoClient.appointmentDefinitions.delete(1)
+    .then(() => {
+        console.log('appointment definition deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Appointment Definition Questions
+
+Retrieves the active booking questionnaire form slots to render for a definition.
+
+```javascript
+omneoClient.appointmentDefinitions.getQuestions(1)
+    .then(({ questionnaire, questions }) => {
+        console.log(questionnaire, questions)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Available Slots
+
+Retrieves bookable slots for a definition at a location on a date. Pass `staff_id` for staff-required definitions. An empty `slots` array means the day is closed or fully booked. The `meta` block echoes the definition settings that shaped the calculation.
+
+```javascript
+const payload = {
+    location_id: 13,
+    date: '2026-05-11'
+}
+
+omneoClient.appointmentDefinitions.availableSlots(1, payload)
+    .then(({ data, meta }) => {
+        console.log(data.slots, meta)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Available Slots Range
+
+Retrieves bookable slots across a date range (capped at 31 days), for calendar views.
+
+```javascript
+const payload = {
+    location_id: 13,
+    start_date: '2026-05-11',
+    end_date: '2026-05-17'
+}
+
+omneoClient.appointmentDefinitions.availableSlotsRange(1, payload)
+    .then(({ data, meta }) => {
+        console.log(data, meta)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Available Staff
+
+Retrieves the eligible staff for a definition at a location on a date, to populate a staff picker. Each staff member reports `has_available_slots`.
+
+```javascript
+const payload = {
+    location_id: 13,
+    date: '2026-05-11'
+}
+
+omneoClient.appointmentDefinitions.availableStaff(1, payload)
+    .then(({ data, meta }) => {
+        console.log(data, meta)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-definitions/index.ts
+++ b/src/omneo/resources/appointment-definitions/index.ts
@@ -1,0 +1,91 @@
+import { RequestParams, AppointmentDefinition, AppointmentDefinitionResponse, CreateAppointmentDefinitionInput, UpdateAppointmentDefinitionInput, AppointmentDefinitionQuestions, AppointmentAvailableSlotsInput, AppointmentAvailableSlotsResponse, AppointmentAvailableSlotsRangeInput, AppointmentAvailableSlotsRangeResponse, AppointmentAvailableStaffInput, AppointmentAvailableStaffResponse } from '@types'
+import Resource from '../resource.js'
+import AppointmentDefinitionLocations from './locations'
+import AppointmentDefinitionNormalHours from './normal-hours'
+import AppointmentDefinitionSpecialHours from './special-hours'
+import AppointmentDefinitionStaff from './staff'
+
+export default class AppointmentDefinitions extends Resource {
+  locations = new AppointmentDefinitionLocations(this.client)
+  normalHours = new AppointmentDefinitionNormalHours(this.client)
+  specialHours = new AppointmentDefinitionSpecialHours(this.client)
+  staff = new AppointmentDefinitionStaff(this.client)
+
+  get (id: number, params?: RequestParams): Promise<AppointmentDefinition> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (params?: RequestParams): Promise<AppointmentDefinitionResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/appointment-definitions',
+      params
+    })
+  }
+
+  create (body: CreateAppointmentDefinitionInput): Promise<AppointmentDefinition> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: '/appointment-definitions',
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (id: number, body: UpdateAppointmentDefinitionInput): Promise<AppointmentDefinition> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-definitions/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-definitions/${id}`
+    })
+  }
+
+  getQuestions (definitionID: number): Promise<AppointmentDefinitionQuestions> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/questions`
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  availableSlots (definitionID: number, body: AppointmentAvailableSlotsInput): Promise<AppointmentAvailableSlotsResponse> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/available-slots`,
+      body
+    })
+  }
+
+  availableSlotsRange (definitionID: number, body: AppointmentAvailableSlotsRangeInput): Promise<AppointmentAvailableSlotsRangeResponse> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/available-slots-range`,
+      body
+    })
+  }
+
+  availableStaff (definitionID: number, body: AppointmentAvailableStaffInput): Promise<AppointmentAvailableStaffResponse> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/available-staff`,
+      body
+    })
+  }
+}

--- a/src/omneo/resources/appointment-definitions/locations/README.md
+++ b/src/omneo/resources/appointment-definitions/locations/README.md
@@ -1,0 +1,78 @@
+## Appointment Definition Locations
+
+Manage the locations an appointment definition is offered at.
+
+### List Appointment Definition Locations
+
+Retrieves the location assignments for a definition.
+
+```javascript
+omneoClient.appointmentDefinitions.locations.list(1)
+    .then((locations) => {
+        console.log(locations)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Appointment Definition Location
+
+Retrieves a specific location assignment by its assignment row ID.
+
+```javascript
+omneoClient.appointmentDefinitions.locations.get(1, 500)
+    .then((location) => {
+        console.log(location)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Definition Location
+
+Offers the definition at a location.
+
+```javascript
+const payload = {
+    location_id: 13,
+    is_active: true
+}
+
+omneoClient.appointmentDefinitions.locations.create(1, payload)
+    .then((location) => {
+        console.log(location)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Definition Location
+
+Updates a location assignment, for example to deactivate it. Note the update route resolves the location ID (here `13`), unlike get and delete which resolve the assignment row ID.
+
+```javascript
+omneoClient.appointmentDefinitions.locations.update(1, 13, { is_active: false })
+    .then((location) => {
+        console.log(location)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Definition Location
+
+Removes a location assignment from the definition by its assignment row ID.
+
+```javascript
+omneoClient.appointmentDefinitions.locations.delete(1, 500)
+    .then(() => {
+        console.log('appointment definition location deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-definitions/locations/index.ts
+++ b/src/omneo/resources/appointment-definitions/locations/index.ts
@@ -1,0 +1,54 @@
+import { RequestParams, AppointmentDefinitionLocation, CreateAppointmentDefinitionLocationInput, UpdateAppointmentDefinitionLocationInput } from '@types'
+import Resource from '../../resource.js'
+
+export default class AppointmentDefinitionLocations extends Resource {
+  // Not Paginated
+  list (definitionID: number, params?: RequestParams): Promise<AppointmentDefinitionLocation[]> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/locations`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  get (definitionID: number, id: number, params?: RequestParams): Promise<AppointmentDefinitionLocation> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/locations/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  create (definitionID: number, body: CreateAppointmentDefinitionLocationInput): Promise<AppointmentDefinitionLocation> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/locations`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  // Omneo API quirk: update resolves the location id, while get and delete
+  // resolve the attachment row id
+  update (definitionID: number, locationID: number, body: UpdateAppointmentDefinitionLocationInput): Promise<AppointmentDefinitionLocation> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-definitions/${definitionID}/locations/${locationID}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (definitionID: number, id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-definitions/${definitionID}/locations/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/appointment-definitions/normal-hours/README.md
+++ b/src/omneo/resources/appointment-definitions/normal-hours/README.md
@@ -1,0 +1,79 @@
+## Appointment Definition Normal Hours
+
+Manage a definition's weekly opening-hours pattern, one entry per `day_of_week` (`MON`–`SUN`). Times are plain local times at the location.
+
+### List Appointment Definition Normal Hours
+
+Retrieves the weekly entries for a definition.
+
+```javascript
+omneoClient.appointmentDefinitions.normalHours.list(1)
+    .then((normalHours) => {
+        console.log(normalHours)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Appointment Definition Normal Hour
+
+Retrieves a specific entry by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.normalHours.get(1, 301)
+    .then((normalHour) => {
+        console.log(normalHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Definition Normal Hour
+
+Adds one weekly entry.
+
+```javascript
+const payload = {
+    day_of_week: 'MON',
+    available_from: '09:00',
+    available_until: '17:00'
+}
+
+omneoClient.appointmentDefinitions.normalHours.create(1, payload)
+    .then((normalHour) => {
+        console.log(normalHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Definition Normal Hour
+
+Updates an entry by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.normalHours.update(1, 301, { available_until: '18:00' })
+    .then((normalHour) => {
+        console.log(normalHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Definition Normal Hour
+
+Deletes an entry by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.normalHours.delete(1, 301)
+    .then(() => {
+        console.log('appointment definition normal hour deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-definitions/normal-hours/index.ts
+++ b/src/omneo/resources/appointment-definitions/normal-hours/index.ts
@@ -1,0 +1,52 @@
+import { RequestParams, AppointmentDefinitionNormalHour, CreateAppointmentDefinitionNormalHourInput, UpdateAppointmentDefinitionNormalHourInput } from '@types'
+import Resource from '../../resource.js'
+
+export default class AppointmentDefinitionNormalHours extends Resource {
+  // Not Paginated
+  list (definitionID: number, params?: RequestParams): Promise<AppointmentDefinitionNormalHour[]> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/normal-hours`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  get (definitionID: number, id: number, params?: RequestParams): Promise<AppointmentDefinitionNormalHour> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/normal-hours/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  create (definitionID: number, body: CreateAppointmentDefinitionNormalHourInput): Promise<AppointmentDefinitionNormalHour> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/normal-hours`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (definitionID: number, id: number, body: UpdateAppointmentDefinitionNormalHourInput): Promise<AppointmentDefinitionNormalHour> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-definitions/${definitionID}/normal-hours/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (definitionID: number, id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-definitions/${definitionID}/normal-hours/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/appointment-definitions/special-hours/README.md
+++ b/src/omneo/resources/appointment-definitions/special-hours/README.md
@@ -1,0 +1,82 @@
+## Appointment Definition Special Hours
+
+Manage a definition's dated opening-hours overrides, such as public holidays. A special hour takes precedence over the normal hour when a date matches.
+
+### List Appointment Definition Special Hours
+
+Retrieves the dated overrides for a definition.
+
+```javascript
+omneoClient.appointmentDefinitions.specialHours.list(1)
+    .then((specialHours) => {
+        console.log(specialHours)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Appointment Definition Special Hour
+
+Retrieves a specific override by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.specialHours.get(1, 88)
+    .then((specialHour) => {
+        console.log(specialHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Definition Special Hour
+
+Adds one dated override.
+
+```javascript
+const payload = {
+    name: 'Public holiday',
+    start_at: '2026-12-25',
+    end_at: '2026-12-25',
+    is_repeating: false,
+    available_from: '10:00',
+    available_until: '14:00'
+}
+
+omneoClient.appointmentDefinitions.specialHours.create(1, payload)
+    .then((specialHour) => {
+        console.log(specialHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Definition Special Hour
+
+Updates an override by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.specialHours.update(1, 88, { available_until: '15:00' })
+    .then((specialHour) => {
+        console.log(specialHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Definition Special Hour
+
+Deletes an override by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.specialHours.delete(1, 88)
+    .then(() => {
+        console.log('appointment definition special hour deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-definitions/special-hours/index.ts
+++ b/src/omneo/resources/appointment-definitions/special-hours/index.ts
@@ -1,0 +1,52 @@
+import { RequestParams, AppointmentDefinitionSpecialHour, CreateAppointmentDefinitionSpecialHourInput, UpdateAppointmentDefinitionSpecialHourInput } from '@types'
+import Resource from '../../resource.js'
+
+export default class AppointmentDefinitionSpecialHours extends Resource {
+  // Not Paginated
+  list (definitionID: number, params?: RequestParams): Promise<AppointmentDefinitionSpecialHour[]> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/special-hours`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  get (definitionID: number, id: number, params?: RequestParams): Promise<AppointmentDefinitionSpecialHour> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/special-hours/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  create (definitionID: number, body: CreateAppointmentDefinitionSpecialHourInput): Promise<AppointmentDefinitionSpecialHour> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/special-hours`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (definitionID: number, id: number, body: UpdateAppointmentDefinitionSpecialHourInput): Promise<AppointmentDefinitionSpecialHour> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-definitions/${definitionID}/special-hours/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (definitionID: number, id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-definitions/${definitionID}/special-hours/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/appointment-definitions/staff/README.md
+++ b/src/omneo/resources/appointment-definitions/staff/README.md
@@ -1,0 +1,78 @@
+## Appointment Definition Staff
+
+Manage the explicit staff attached to an appointment definition. Only used when the definition has `use_staff_from_location: false`; otherwise availability draws from the location's staff.
+
+### List Appointment Definition Staff
+
+Retrieves the staff attached to a definition.
+
+```javascript
+omneoClient.appointmentDefinitions.staff.list(1)
+    .then((staff) => {
+        console.log(staff)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Appointment Definition Staff
+
+Retrieves a specific staff attachment by ID.
+
+```javascript
+omneoClient.appointmentDefinitions.staff.get(1, 700)
+    .then((staff) => {
+        console.log(staff)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Definition Staff
+
+Attaches a staff member (by their profile UUID) to the definition.
+
+```javascript
+const payload = {
+    staff_id: 'c3d582d4-b75f-47a9-d6fd-1d2b41d77e24',
+    is_active: true
+}
+
+omneoClient.appointmentDefinitions.staff.create(1, payload)
+    .then((staff) => {
+        console.log(staff)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Definition Staff
+
+Updates a staff attachment, for example to deactivate it.
+
+```javascript
+omneoClient.appointmentDefinitions.staff.update(1, 700, { is_active: false })
+    .then((staff) => {
+        console.log(staff)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Definition Staff
+
+Removes a staff attachment from the definition.
+
+```javascript
+omneoClient.appointmentDefinitions.staff.delete(1, 700)
+    .then(() => {
+        console.log('appointment definition staff deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-definitions/staff/index.ts
+++ b/src/omneo/resources/appointment-definitions/staff/index.ts
@@ -1,0 +1,52 @@
+import { RequestParams, AppointmentDefinitionStaff as AppointmentDefinitionStaffRecord, CreateAppointmentDefinitionStaffInput, UpdateAppointmentDefinitionStaffInput } from '@types'
+import Resource from '../../resource.js'
+
+export default class AppointmentDefinitionStaff extends Resource {
+  // Not Paginated
+  list (definitionID: number, params?: RequestParams): Promise<AppointmentDefinitionStaffRecord[]> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/staff`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  get (definitionID: number, id: number, params?: RequestParams): Promise<AppointmentDefinitionStaffRecord> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-definitions/${definitionID}/staff/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  create (definitionID: number, body: CreateAppointmentDefinitionStaffInput): Promise<AppointmentDefinitionStaffRecord> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointment-definitions/${definitionID}/staff`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (definitionID: number, id: number, body: UpdateAppointmentDefinitionStaffInput): Promise<AppointmentDefinitionStaffRecord> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-definitions/${definitionID}/staff/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (definitionID: number, id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-definitions/${definitionID}/staff/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/appointment-queues/README.md
+++ b/src/omneo/resources/appointment-queues/README.md
@@ -1,0 +1,84 @@
+## Appointment Queues
+
+Manage walk-in queue entries for definitions that allow walk-ins. An entry moves through `waiting` → `called` → `served`, or `cancelled`. A served entry can be converted into an appointment by setting `appointment_id`.
+
+### Get Appointment Queue
+
+Retrieves a specific queue entry by ID.
+
+```javascript
+omneoClient.appointmentQueues.get(812)
+    .then((queueEntry) => {
+        console.log(queueEntry)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Appointment Queues
+
+Retrieves a list of all queue entries. Supports filters such as `filter[status]`, `filter[location_id]` and `filter[appointment_definition_id]`.
+
+```javascript
+const params = {
+    'filter[status]': 'waiting'
+}
+
+omneoClient.appointmentQueues.list(params)
+    .then((queueEntries) => {
+        console.log(queueEntries)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Queue
+
+Checks a customer into the walk-in queue. Omit `profile_id` for an anonymous walk-in.
+
+```javascript
+const payload = {
+    appointment_definition_id: 1,
+    location_id: 13,
+    profile_id: 'a1b460b2-953f-4587-b4eb-fb0f29b55e02',
+    notes: 'Walk-in, wants a fitting'
+}
+
+omneoClient.appointmentQueues.create(payload)
+    .then((queueEntry) => {
+        console.log(queueEntry)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Queue
+
+Advances a queue entry through its lifecycle, or links the appointment created for a served entry.
+
+```javascript
+omneoClient.appointmentQueues.update(812, { status: 'called' })
+    .then((queueEntry) => {
+        console.log(queueEntry)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Queue
+
+Deletes a queue entry by ID.
+
+```javascript
+omneoClient.appointmentQueues.delete(812)
+    .then(() => {
+        console.log('appointment queue deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-queues/index.ts
+++ b/src/omneo/resources/appointment-queues/index.ts
@@ -1,0 +1,49 @@
+import { RequestParams, AppointmentQueue, AppointmentQueueResponse, CreateAppointmentQueueInput, UpdateAppointmentQueueInput } from '@types'
+import Resource from '../resource.js'
+
+export default class AppointmentQueues extends Resource {
+  get (id: number, params?: RequestParams): Promise<AppointmentQueue> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-queues/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (params?: RequestParams): Promise<AppointmentQueueResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/appointment-queues',
+      params
+    })
+  }
+
+  create (body: CreateAppointmentQueueInput): Promise<AppointmentQueue> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: '/appointment-queues',
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (id: number, body: UpdateAppointmentQueueInput): Promise<AppointmentQueue> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-queues/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-queues/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/appointment-waitlists/README.md
+++ b/src/omneo/resources/appointment-waitlists/README.md
@@ -1,0 +1,89 @@
+## Appointment Waitlists
+
+Manage waitlist entries for customers registering interest when no suitable slot is available. An entry moves through `active`, then `fulfilled` (when an appointment is created and linked) or `cancelled`.
+
+### Get Appointment Waitlist
+
+Retrieves a specific waitlist entry by ID.
+
+```javascript
+omneoClient.appointmentWaitlists.get(1)
+    .then((waitlistEntry) => {
+        console.log(waitlistEntry)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Appointment Waitlists
+
+Retrieves a list of all waitlist entries. Supports filters such as `filter[status]`, `filter[profile_id]` and `filter[appointment_definition_id]`.
+
+```javascript
+const params = {
+    'filter[status]': 'active'
+}
+
+omneoClient.appointmentWaitlists.list(params)
+    .then((waitlistEntries) => {
+        console.log(waitlistEntries)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment Waitlist
+
+Registers a customer's interest for a definition at a location, optionally with a desired start time.
+
+```javascript
+const payload = {
+    appointment_definition_id: 1,
+    profile_id: 'a1b460b2-953f-4587-b4eb-fb0f29b55e02',
+    location_id: 13,
+    desired_start_at: '2026-05-11 10:00:00'
+}
+
+omneoClient.appointmentWaitlists.create(payload)
+    .then((waitlistEntry) => {
+        console.log(waitlistEntry)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment Waitlist
+
+Updates a waitlist entry, for example fulfilling it with the appointment created for the customer.
+
+```javascript
+const payload = {
+    status: 'fulfilled',
+    appointment_id: 5012
+}
+
+omneoClient.appointmentWaitlists.update(1, payload)
+    .then((waitlistEntry) => {
+        console.log(waitlistEntry)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment Waitlist
+
+Deletes a waitlist entry by ID.
+
+```javascript
+omneoClient.appointmentWaitlists.delete(1)
+    .then(() => {
+        console.log('appointment waitlist deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointment-waitlists/index.ts
+++ b/src/omneo/resources/appointment-waitlists/index.ts
@@ -1,0 +1,49 @@
+import { RequestParams, AppointmentWaitlist, AppointmentWaitlistResponse, CreateAppointmentWaitlistInput, UpdateAppointmentWaitlistInput } from '@types'
+import Resource from '../resource.js'
+
+export default class AppointmentWaitlists extends Resource {
+  get (id: number, params?: RequestParams): Promise<AppointmentWaitlist> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointment-waitlists/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (params?: RequestParams): Promise<AppointmentWaitlistResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/appointment-waitlists',
+      params
+    })
+  }
+
+  create (body: CreateAppointmentWaitlistInput): Promise<AppointmentWaitlist> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: '/appointment-waitlists',
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (id: number, body: UpdateAppointmentWaitlistInput): Promise<AppointmentWaitlist> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointment-waitlists/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointment-waitlists/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/appointments/README.md
+++ b/src/omneo/resources/appointments/README.md
@@ -1,0 +1,119 @@
+## Appointments
+
+Manage appointments, which are bookings made against an appointment definition. Setting `status` to `cancelled` preserves the record with its `cancelled_at` timestamp, which is usually preferable to deleting for reporting.
+
+### Get Appointment
+
+Retrieves a specific appointment by ID.
+
+```javascript
+omneoClient.appointments.get(1)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Appointments
+
+Retrieves a list of all appointments. Supports filters such as `filter[profile_id]`, `filter[appointment_definition_id]`, `filter[status]`, `filter[location_id]` and `filter[assigned_staff_id]`.
+
+```javascript
+const params = {
+    'filter[status]': 'confirmed'
+}
+
+omneoClient.appointments.list(params)
+    .then((appointments) => {
+        console.log(appointments)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Appointment
+
+Creates a new appointment. Times are sent in the request `timezone` and stored in UTC. Pass `assigned_staff_id` when the definition requires staff, and `answers` to capture booking questionnaire answers (create only).
+
+```javascript
+const payload = {
+    appointment_definition_id: 1,
+    profile_id: 'a1b460b2-953f-4587-b4eb-fb0f29b55e02',
+    location_id: 13,
+    scheduled_start_at: '2026-05-11 10:00:00',
+    scheduled_end_at: '2026-05-11 10:30:00',
+    timezone: 'Australia/Melbourne'
+}
+
+omneoClient.appointments.create(payload)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Appointment
+
+Updates an existing appointment by ID. Sending a `status` stamps the matching timestamp automatically (for example `confirmed` sets `confirmed_at`). Attach a transaction or order with a resolver object, or send `null` to detach.
+
+```javascript
+const payload = {
+    status: 'completed',
+    transaction: { receipt_ref: 'R-88123' }
+}
+
+omneoClient.appointments.update(1, payload)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Appointment
+
+Deletes an appointment by ID.
+
+```javascript
+omneoClient.appointments.delete(1)
+    .then(() => {
+        console.log('appointment deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Link Appointment
+
+Links an additional profile or list to an appointment, separate from the profile the appointment is booked for. Linking is idempotent.
+
+```javascript
+omneoClient.appointments.link(1, { type: 'profile', id: 'b2c571c3-a64f-4698-c5fc-0c1a30c66f13' })
+    .then((appointment) => {
+        console.log(appointment.links)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Unlink Appointment
+
+Removes a linked profile or list from an appointment.
+
+```javascript
+omneoClient.appointments.unlink(1, { type: 'list', id: 204 })
+    .then(() => {
+        console.log('appointment unlinked successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/appointments/index.ts
+++ b/src/omneo/resources/appointments/index.ts
@@ -1,0 +1,67 @@
+import { RequestParams, Appointment, AppointmentResponse, CreateAppointmentInput, UpdateAppointmentInput, AppointmentLinkInput } from '@types'
+import Resource from '../resource.js'
+
+export default class Appointments extends Resource {
+  get (id: number, params?: RequestParams): Promise<Appointment> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/appointments/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (params?: RequestParams): Promise<AppointmentResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: '/appointments',
+      params
+    })
+  }
+
+  create (body: CreateAppointmentInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: '/appointments',
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (id: number, body: UpdateAppointmentInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/appointments/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/appointments/${id}`
+    })
+  }
+
+  link (id: number, body: AppointmentLinkInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointments/${id}/link`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  unlink (id: number, body: AppointmentLinkInput): Promise<void> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/appointments/${id}/unlink`,
+      body
+    })
+  }
+}

--- a/src/omneo/resources/auth/README.md
+++ b/src/omneo/resources/auth/README.md
@@ -14,3 +14,21 @@ Here's an example of how to use the `createAPIToken` method:
 const token = await omneoClient.auth.createAPIToken('test-token', ['read-profiles', 'write-profiles'])
 ```
 
+### getAPITokens(params?: RequestParams): Promise<APITokenResponse>
+
+This method lists the tenant's API tokens.
+
+- `params`: Optional query parameters, for example `type` (`current` / `expired`), `filter[name]` and `page[size]` / `page[number]`.
+
+The endpoint is paginated, so this returns the full envelope (`data`, `links`, `meta`) rather than a bare array.
+
+```javascript
+    omneoClient.auth.getAPITokens({ type: 'current', 'filter[name]': 'test-token' })
+        .then((response) => {
+            console.log(response.data)
+        })
+        .catch((error) => {
+            console.error(error)
+        })
+```
+

--- a/src/omneo/resources/auth/index.ts
+++ b/src/omneo/resources/auth/index.ts
@@ -1,4 +1,4 @@
-import { APIToken, APITokenInput } from '@types'
+import { APIToken, APITokenInput, APITokenResponse, RequestParams } from '@types'
 import Resource from '../resource.js'
 
 export default class Auth extends Resource {
@@ -13,13 +13,11 @@ export default class Auth extends Resource {
     })
   }
 
-  getAPITokens (params: object): Promise<APIToken[]> {
+  getAPITokens (params?: RequestParams): Promise<APITokenResponse> {
     return this.client.call({
       method: 'get',
       endpoint: '/auth/access-tokens',
       params
-    }).then((response) => {
-      return response
     })
   }
 

--- a/src/omneo/resources/profiles/README.md
+++ b/src/omneo/resources/profiles/README.md
@@ -2,14 +2,17 @@
 
 - [Addresses](./addresses/README.md)
 - [Aggregations](./aggregations/README.md)
+- [Appointments](./appointments/README.md)
 - [Balances](./balances/README.md)
 - [Connections](./connections/README.md)
 - [Identities](./identities/README.md)
 - [Interactions](./interactions/README.md)
 - [Ledgers](./ledgers/README.md)
+- [Normal Hours](./normal-hours/README.md)
 - [Points](./points/README.md)
 - [Regions](./regions/README.md)
 - [Rewards](./rewards/README.md)
+- [Special Hours](./special-hours/README.md)
 - [Tiers](./tiers/README.md)
 - [Transactions](./transactions/README.md)
 

--- a/src/omneo/resources/profiles/appointments/README.md
+++ b/src/omneo/resources/profiles/appointments/README.md
@@ -1,0 +1,99 @@
+## Profile Appointments
+
+Manage appointments for a specific profile. The profile-scoped routes infer `profile_id` from the URL, and return 404 when an appointment does not belong to the profile.
+
+### Get Profile Appointment
+
+Retrieves one of the profile's appointments by ID.
+
+```javascript
+omneoClient.profiles.appointments.get('a1b460b2-953f-4587-b4eb-fb0f29b55e02', 5012)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Profile Appointments
+
+Retrieves the profile's appointments. Pass `filter[status]` to narrow the results.
+
+```javascript
+const params = {
+    'filter[status]': 'confirmed'
+}
+
+omneoClient.profiles.appointments.list('a1b460b2-953f-4587-b4eb-fb0f29b55e02', params)
+    .then((appointments) => {
+        console.log(appointments)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Profile Appointment
+
+Books an appointment for the profile. `profile_id` comes from the URL, so it is not sent in the body.
+
+```javascript
+const payload = {
+    appointment_definition_id: 1,
+    location_id: 13,
+    scheduled_start_at: '2026-05-11 10:00:00',
+    scheduled_end_at: '2026-05-11 10:30:00',
+    timezone: 'Australia/Melbourne'
+}
+
+omneoClient.profiles.appointments.create('a1b460b2-953f-4587-b4eb-fb0f29b55e02', payload)
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Profile Appointment
+
+Updates or reschedules one of the profile's appointments.
+
+```javascript
+omneoClient.profiles.appointments.update('a1b460b2-953f-4587-b4eb-fb0f29b55e02', 5012, { status: 'cancelled' })
+    .then((appointment) => {
+        console.log(appointment)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Profile Appointment
+
+Deletes one of the profile's appointments.
+
+```javascript
+omneoClient.profiles.appointments.delete('a1b460b2-953f-4587-b4eb-fb0f29b55e02', 5012)
+    .then(() => {
+        console.log('profile appointment deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### List Visible Appointment Definitions
+
+Retrieves the published, non-archived appointment definitions whose `visibility_condition` evaluates to true for the profile.
+
+```javascript
+omneoClient.profiles.appointments.listVisibleDefinitions('a1b460b2-953f-4587-b4eb-fb0f29b55e02')
+    .then((definitions) => {
+        console.log(definitions)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/profiles/appointments/index.ts
+++ b/src/omneo/resources/profiles/appointments/index.ts
@@ -1,0 +1,57 @@
+import { RequestParams, Appointment, AppointmentResponse, AppointmentDefinitionResponse, CreateProfileAppointmentInput, UpdateAppointmentInput } from '@types'
+import Resource from '@omneo/resources/resource'
+
+export default class ProfileAppointments extends Resource {
+  get (profileID: string, appointmentID: number, params?: RequestParams): Promise<Appointment> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/appointments/${appointmentID}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  list (profileID: string, params?: RequestParams): Promise<AppointmentResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/appointments`,
+      params
+    })
+  }
+
+  create (profileID: string, body: CreateProfileAppointmentInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/profiles/${profileID}/appointments`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (profileID: string, appointmentID: number, body: UpdateAppointmentInput): Promise<Appointment> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/profiles/${profileID}/appointments/${appointmentID}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (profileID: string, appointmentID: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/profiles/${profileID}/appointments/${appointmentID}`
+    })
+  }
+
+  listVisibleDefinitions (profileID: string, params?: RequestParams): Promise<AppointmentDefinitionResponse> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/appointment-definitions/visibility`,
+      params
+    })
+  }
+}

--- a/src/omneo/resources/profiles/index.ts
+++ b/src/omneo/resources/profiles/index.ts
@@ -39,10 +39,14 @@ import createProfileByDelegation from '../profiles/createProfileByDelegation.js'
 import Resource from '../resource'
 import ProfilePoints from './points'
 import ProfileLedgers from './ledgers'
+import ProfileAppointments from './appointments'
+import ProfileNormalHours from './normal-hours'
+import ProfileSpecialHours from './special-hours'
 export default class Profiles extends Resource {
   achievements = new ProfileAchievements(this.client)
   addresses = new ProfileAddresses(this.client)
   aggregations = new ProfileAggregations(this.client)
+  appointments = new ProfileAppointments(this.client)
   attributes = {
     appearance: new ProfileAttributesAppearance(this.client),
     comms: new ProfileAttributesComms(this.client),
@@ -58,12 +62,14 @@ export default class Profiles extends Resource {
   interactions = new ProfileInteractions(this.client)
   ledgers = new ProfileLedgers(this.client)
   lists = new ProfileLists(this.client)
+  normalHours = new ProfileNormalHours(this.client)
 
   orders = new ProfileOrders(this.client)
   points = new ProfilePoints(this.client)
   redemptions = new ProfileRedemptions(this.client)
   regions = new ProfileRegions(this.client)
   rewards = new ProfileRewards(this.client)
+  specialHours = new ProfileSpecialHours(this.client)
   tiers = new ProfileTiers(this.client)
   transactionClaims = new ProfileTransactionClaims(this.client)
   transactions = new ProfileTransactions(this.client)

--- a/src/omneo/resources/profiles/normal-hours/README.md
+++ b/src/omneo/resources/profiles/normal-hours/README.md
@@ -1,0 +1,79 @@
+## Profile Normal Hours
+
+Manage a profile's weekly working-hours pattern, one entry per `day_of_week` (`MON`–`SUN`). For staff profiles, these hours gate individual availability on staff-required appointment definitions.
+
+### List Profile Normal Hours
+
+Retrieves the profile's weekly entries.
+
+```javascript
+omneoClient.profiles.normalHours.list('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24')
+    .then((normalHours) => {
+        console.log(normalHours)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Profile Normal Hour
+
+Retrieves a specific entry by ID.
+
+```javascript
+omneoClient.profiles.normalHours.get('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', 301)
+    .then((normalHour) => {
+        console.log(normalHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Profile Normal Hour
+
+Adds one weekly entry.
+
+```javascript
+const payload = {
+    day_of_week: 'MON',
+    available_from: '09:00',
+    available_until: '17:00'
+}
+
+omneoClient.profiles.normalHours.create('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', payload)
+    .then((normalHour) => {
+        console.log(normalHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Profile Normal Hour
+
+Updates an entry by ID.
+
+```javascript
+omneoClient.profiles.normalHours.update('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', 301, { available_until: '18:00' })
+    .then((normalHour) => {
+        console.log(normalHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Profile Normal Hour
+
+Deletes an entry by ID.
+
+```javascript
+omneoClient.profiles.normalHours.delete('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', 301)
+    .then(() => {
+        console.log('profile normal hour deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/profiles/normal-hours/index.ts
+++ b/src/omneo/resources/profiles/normal-hours/index.ts
@@ -1,0 +1,52 @@
+import { RequestParams, ProfileNormalHour, CreateProfileNormalHourInput, UpdateProfileNormalHourInput } from '@types'
+import Resource from '@omneo/resources/resource'
+
+export default class ProfileNormalHours extends Resource {
+  // Not Paginated
+  list (profileID: string, params?: RequestParams): Promise<ProfileNormalHour[]> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/normal-hours`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  get (profileID: string, id: number, params?: RequestParams): Promise<ProfileNormalHour> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/normal-hours/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  create (profileID: string, body: CreateProfileNormalHourInput): Promise<ProfileNormalHour> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/profiles/${profileID}/normal-hours`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (profileID: string, id: number, body: UpdateProfileNormalHourInput): Promise<ProfileNormalHour> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/profiles/${profileID}/normal-hours/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (profileID: string, id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/profiles/${profileID}/normal-hours/${id}`
+    })
+  }
+}

--- a/src/omneo/resources/profiles/special-hours/README.md
+++ b/src/omneo/resources/profiles/special-hours/README.md
@@ -1,0 +1,80 @@
+## Profile Special Hours
+
+Manage a profile's dated working-hours overrides, such as leave or a one-off change. A special hour takes precedence over the normal hour when a date matches.
+
+### List Profile Special Hours
+
+Retrieves the profile's dated overrides.
+
+```javascript
+omneoClient.profiles.specialHours.list('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24')
+    .then((specialHours) => {
+        console.log(specialHours)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Get Profile Special Hour
+
+Retrieves a specific override by ID.
+
+```javascript
+omneoClient.profiles.specialHours.get('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', 88)
+    .then((specialHour) => {
+        console.log(specialHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Create Profile Special Hour
+
+Adds one dated override.
+
+```javascript
+const payload = {
+    name: 'Annual leave',
+    start_at: '2026-12-24',
+    end_at: '2026-12-26',
+    is_repeating: false
+}
+
+omneoClient.profiles.specialHours.create('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', payload)
+    .then((specialHour) => {
+        console.log(specialHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Update Profile Special Hour
+
+Updates an override by ID.
+
+```javascript
+omneoClient.profiles.specialHours.update('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', 88, { end_at: '2026-12-27' })
+    .then((specialHour) => {
+        console.log(specialHour)
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```
+
+### Delete Profile Special Hour
+
+Deletes an override by ID.
+
+```javascript
+omneoClient.profiles.specialHours.delete('c3d582d4-b75f-47a9-d6fd-1d2b41d77e24', 88)
+    .then(() => {
+        console.log('profile special hour deleted successfully')
+    })
+    .catch((error) => {
+        console.error(error)
+    })
+```

--- a/src/omneo/resources/profiles/special-hours/index.ts
+++ b/src/omneo/resources/profiles/special-hours/index.ts
@@ -1,0 +1,52 @@
+import { RequestParams, ProfileSpecialHour, CreateProfileSpecialHourInput, UpdateProfileSpecialHourInput } from '@types'
+import Resource from '@omneo/resources/resource'
+
+export default class ProfileSpecialHours extends Resource {
+  // Not Paginated
+  list (profileID: string, params?: RequestParams): Promise<ProfileSpecialHour[]> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/special-hours`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  get (profileID: string, id: number, params?: RequestParams): Promise<ProfileSpecialHour> {
+    return this.client.call({
+      method: 'GET',
+      endpoint: `/profiles/${profileID}/special-hours/${id}`,
+      params
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  create (profileID: string, body: CreateProfileSpecialHourInput): Promise<ProfileSpecialHour> {
+    return this.client.call({
+      method: 'POST',
+      endpoint: `/profiles/${profileID}/special-hours`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  update (profileID: string, id: number, body: UpdateProfileSpecialHourInput): Promise<ProfileSpecialHour> {
+    return this.client.call({
+      method: 'PUT',
+      endpoint: `/profiles/${profileID}/special-hours/${id}`,
+      body
+    }).then((response) => {
+      return response.data
+    })
+  }
+
+  delete (profileID: string, id: number): Promise<void> {
+    return this.client.call({
+      method: 'DELETE',
+      endpoint: `/profiles/${profileID}/special-hours/${id}`
+    })
+  }
+}

--- a/src/tests/integration/id/profile/appointments/id-appointments.test.ts
+++ b/src/tests/integration/id/profile/appointments/id-appointments.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { ID } from '@id'
+import { simpleOmneoRequest, simpleIDRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+// Skipped: the ID API routes /profiles/me/appointments and
+// /profiles/me/appointment-definitions/visibility exist, but currently
+// return 403 "Invalid scope(s) provided." for profile tokens minted via
+// /auth/token (verified 2026-08-04). Unskip once the platform enables the
+// appointment scopes on ID tokens.
+describe.skip('ID appointments', () => {
+  let locationID: number
+  let profile: any
+  let definition: any
+  let seededAppointment: any
+  let IDClient: ID
+
+  beforeAll(async () => {
+    const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+    locationID = locations[0].id
+
+    profile = await simpleOmneoRequest('POST', '/profiles', {
+      first_name: 'SDK',
+      last_name: 'ID Appointment Test',
+      email: `${getRandomString('sdk_unit_test_id_appointments')}@omneodemo.com`
+    }).then(({ data }) => data)
+    CREATED_PROFILE_IDS.push(profile.id)
+
+    definition = await seedAppointmentDefinition({
+      handle: getRandomString('sdk_unit_test_id_appointments_handle'),
+      name: getRandomString('sdk_unit_test_id_appointments_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: DEFINITION_ALL_WEEK_HOURS,
+      min_lead_minutes: 0,
+      allow_customer_booking: true,
+      is_published: true,
+      location_ids: [locationID],
+      visibility_condition: { '==': [1, 1] }
+    }).then(({ data }) => data)
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+    seededAppointment = await simpleOmneoRequest('POST', '/appointments', {
+      appointment_definition_id: definition.id,
+      profile_id: profile.id,
+      location_id: locationID,
+      scheduled_start_at: `${futureDate(3)} 10:00:00`,
+      scheduled_end_at: `${futureDate(3)} 10:30:00`,
+      timezone: 'Australia/Melbourne'
+    }).then(({ data }) => data)
+    CREATED_APPOINTMENT_IDS.push(seededAppointment.id)
+
+    const tokenData = await simpleIDRequest('POST', 'auth/token', process.env.OMNEO_TOKEN, { id: profile.id })
+      .then(({ data }) => data)
+
+    IDClient = new ID({
+      tenant: process.env.OMNEO_TENANT as string,
+      omneoAPIToken: process.env.OMNEO_TOKEN as string,
+      IDToken: tokenData.token,
+      IDTokenExpiry: tokenData.exp
+    })
+  })
+
+  test('ID SDK can list the profile appointments', async () => {
+    const response = await IDClient.profile.appointments.list().catch((err) => {
+      console.error('ID SDK List Appointments failed:', err)
+      throw new Error('ID SDK List Appointments failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((appointment) => appointment.id === seededAppointment.id)).toBeDefined()
+  })
+
+  test('ID SDK can get an appointment', async () => {
+    const appointment = await IDClient.profile.appointments.get(seededAppointment.id).catch((err) => {
+      console.error('ID SDK Get Appointment failed:', err)
+      throw new Error('ID SDK Get Appointment failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(appointment.id).toBe(seededAppointment.id)
+    expect(appointment.profile_id).toBe(profile.id)
+  })
+
+  test('ID SDK can create an appointment', async () => {
+    const appointment = await IDClient.profile.appointments.create({
+      appointment_definition_id: definition.id,
+      location_id: locationID,
+      scheduled_start_at: `${futureDate(4)} 11:00:00`,
+      scheduled_end_at: `${futureDate(4)} 11:30:00`,
+      timezone: 'Australia/Melbourne'
+    }).catch((err) => {
+      console.error('ID SDK Create Appointment failed:', err)
+      throw new Error('ID SDK Create Appointment failed')
+    })
+    CREATED_APPOINTMENT_IDS.push(appointment.id)
+
+    expect(appointment).toBeDefined()
+    expect(appointment.profile_id).toBe(profile.id)
+    expect(appointment.appointment_definition_id).toBe(definition.id)
+  })
+
+  test('ID SDK can update an appointment', async () => {
+    const appointment = await IDClient.profile.appointments.update(seededAppointment.id, {
+      status: 'cancelled'
+    }).catch((err) => {
+      console.error('ID SDK Update Appointment failed:', err)
+      throw new Error('ID SDK Update Appointment failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(appointment.status).toBe('cancelled')
+    expect(appointment.cancelled_at).not.toBeNull()
+  })
+
+  test('ID SDK can list visible appointment definitions', async () => {
+    const response = await IDClient.profile.appointments.listVisibleDefinitions().catch((err) => {
+      console.error('ID SDK List Visible Appointment Definitions failed:', err)
+      throw new Error('ID SDK List Visible Appointment Definitions failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((item) => item.id === definition.id)).toBeDefined()
+  })
+
+  test('ID SDK can delete an appointment', async () => {
+    await IDClient.profile.appointments.delete(seededAppointment.id).catch((err) => {
+      console.error('ID SDK Delete Appointment failed:', err)
+      throw new Error('ID SDK Delete Appointment failed')
+    })
+
+    const response = await simpleOmneoRequest('GET', `/appointments/${seededAppointment.id}`)
+    expect(response.status).toBe(404)
+    CREATED_APPOINTMENT_IDS.splice(CREATED_APPOINTMENT_IDS.indexOf(seededAppointment.id), 1)
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/id/profile/tiers/id-assign-profile-tier.test.ts
+++ b/src/tests/integration/id/profile/tiers/id-assign-profile-tier.test.ts
@@ -11,12 +11,14 @@ describe('ID Profile Tiers - Assign', () => {
     const { tokenData } = IDData
     let tierDefinition: any
 
-    // First, try to get existing tier definitions
+    // First, try to get existing tier definitions. The assign endpoint only
+    // resolves assignable definitions, so a non-assignable one (e.g. the floor
+    // tier) 404s with "No query results for model [App\Models\TierDefinition]"
     const existingDefinitions = await simpleOmneoRequest('GET', '/tiers/definitions')
 
-    if (existingDefinitions.data && existingDefinitions.data.length > 0) {
-      // Use the first existing tier definition
-      tierDefinition = { data: existingDefinitions.data[0] }
+    const assignableDefinition = existingDefinitions.data?.find((definition: any) => definition.is_assignable)
+    if (assignableDefinition) {
+      tierDefinition = { data: assignableDefinition }
     } else {
       // Create a new tier definition if none exist
       const tierDefinitionPayload = {

--- a/src/tests/integration/omneo/appointment-definitions/availability.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/availability.test.ts
@@ -45,13 +45,15 @@ beforeAll(async () => {
   staffProfileID = staffProfile.id
   CREATED_PROFILE_IDS.push(staffProfile.id)
 
-  for (const day of ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']) {
-    await simpleOmneoRequest('POST', `/profiles/${staffProfileID}/normal-hours`, {
+  // Seeded in parallel — seven serial round trips push this hook past the
+  // hook timeout when the full suite is running
+  await Promise.all(['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'].map((day) => {
+    return simpleOmneoRequest('POST', `/profiles/${staffProfileID}/normal-hours`, {
       day_of_week: day,
       available_from: '09:00',
       available_until: '17:00'
     })
-  }
+  }))
 
   const staffSeeded = await seedAppointmentDefinition({
     handle: getRandomString('sdk_unit_test_availability_staff_handle'),

--- a/src/tests/integration/omneo/appointment-definitions/availability.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/availability.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { simpleOmneoRequest, getRandomString, seedAppointmentTestLocation, DEFINITION_ALL_WEEK_HOURS, futureDate, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_LOCATION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let staffDefinitionID: number
+let locationID: number
+let staffProfileID: string
+
+beforeAll(async () => {
+  const location = await seedAppointmentTestLocation()
+  locationID = location.id
+  CREATED_LOCATION_IDS.push(location.id)
+
+  const seeded = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_availability_handle'),
+    name: getRandomString('sdk_unit_test_availability_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    min_lead_minutes: 0,
+    max_advance_days: 30,
+    slot_interval_minutes: 30,
+    requires_staff: false,
+    is_published: true,
+    location_ids: [locationID],
+    normal_hours: DEFINITION_ALL_WEEK_HOURS
+  }).then(({ data }) => data)
+  definitionID = seeded.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+
+  // Staff-required definition with an explicit staff member whose own
+  // profile hours gate their availability
+  const staffProfile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Availability Staff',
+    email: `${getRandomString('sdk_unit_test_availability_staff')}@omneodemo.com`
+  }).then(({ data }) => data)
+  staffProfileID = staffProfile.id
+  CREATED_PROFILE_IDS.push(staffProfile.id)
+
+  for (const day of ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']) {
+    await simpleOmneoRequest('POST', `/profiles/${staffProfileID}/normal-hours`, {
+      day_of_week: day,
+      available_from: '09:00',
+      available_until: '17:00'
+    })
+  }
+
+  const staffSeeded = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_availability_staff_handle'),
+    name: getRandomString('sdk_unit_test_availability_staff_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    min_lead_minutes: 0,
+    slot_interval_minutes: 30,
+    requires_staff: true,
+    use_staff_from_location: false,
+    is_published: true,
+    location_ids: [locationID],
+    staff_ids: [staffProfileID],
+    normal_hours: DEFINITION_ALL_WEEK_HOURS
+  }).then(({ data }) => data)
+  staffDefinitionID = staffSeeded.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(staffSeeded.id)
+})
+
+describe('Appointment Availability', () => {
+  test('SDK Browse Available Appointment Slots', async () => {
+    const response = await omneoClient.appointmentDefinitions.availableSlots(definitionID, {
+      location_id: locationID,
+      date: futureDate(3)
+    }).catch((err) => {
+      console.error('SDK Browse Available Appointment Slots failed:', err)
+      throw new Error('SDK Browse Available Appointment Slots failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(response.data).toBeDefined()
+    expect(response.data.appointment_definition_id).toBe(definitionID)
+    expect(response.data.location_id).toBe(locationID)
+    expect(response.data.requires_staff).toBe(false)
+    expect(Array.isArray(response.data.slots)).toBe(true)
+    expect(response.data.slots.length).toBeGreaterThan(0)
+    expect(response.data.slots[0]).toHaveProperty('start_at')
+    expect(response.data.slots[0]).toHaveProperty('end_at')
+    expect(response.data.slots[0].duration_minutes).toBe(30)
+    expect(response.meta).toBeDefined()
+    expect(response.meta.duration_minutes).toBe(30)
+    expect(response.meta.slot_interval_minutes).toBe(30)
+  })
+
+  test('SDK Browse Available Appointment Slots over a Date Range', async () => {
+    const response = await omneoClient.appointmentDefinitions.availableSlotsRange(definitionID, {
+      location_id: locationID,
+      start_date: futureDate(3),
+      end_date: futureDate(5)
+    }).catch((err) => {
+      console.error('SDK Browse Available Appointment Slots Range failed:', err)
+      throw new Error('SDK Browse Available Appointment Slots Range failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.length).toBeGreaterThan(0)
+    expect(response.meta).toBeDefined()
+    expect(response.meta.appointment_definition_id).toBe(definitionID)
+    expect(response.meta.start_date).toBe(futureDate(3))
+    expect(response.meta.end_date).toBe(futureDate(5))
+  })
+
+  test('SDK Browse Available Appointment Staff', async () => {
+    const response = await omneoClient.appointmentDefinitions.availableStaff(staffDefinitionID, {
+      location_id: locationID,
+      date: futureDate(3)
+    }).catch((err) => {
+      console.error('SDK Browse Available Appointment Staff failed:', err)
+      throw new Error('SDK Browse Available Appointment Staff failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((staff) => staff.id === staffProfileID)).toBeDefined()
+    expect(response.meta).toBeDefined()
+    expect(response.meta.appointment_definition_id).toBe(staffDefinitionID)
+    expect(response.meta.requires_staff).toBe(true)
+  })
+
+  test('SDK Browse Available Appointment Staff rejects a non-staff definition', async () => {
+    const error = await omneoClient.appointmentDefinitions.availableStaff(definitionID, {
+      location_id: locationID,
+      date: futureDate(3)
+    }).then(() => null).catch((err) => err)
+
+    expect(error).not.toBeNull()
+    expect(error?.errors?.requires_staff).toBeDefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_LOCATION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/locations/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Location ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Location ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/create-appointment-definition.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/create-appointment-definition.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinition, CreateAppointmentDefinitionInput } from '@types'
+import { simpleOmneoRequest, getRandomString } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+
+// Concurrent definition creates intermittently return a bare 500 from the
+// live API, so retry those; validation errors still fail immediately
+const createDefinitionWithRetry = async (payload: CreateAppointmentDefinitionInput): Promise<AppointmentDefinition> => {
+  let lastError: any
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      return await omneoClient.appointmentDefinitions.create(payload)
+    } catch (err: any) {
+      if (err?.errors) throw err
+      console.log(`Create Appointment Definition attempt ${attempt} hit a server error, retrying`)
+      lastError = err
+    }
+  }
+  throw lastError
+}
+
+describe('Create Appointment Definition', () => {
+  test('SDK Create Appointment Definition', async () => {
+    const payload: CreateAppointmentDefinitionInput = {
+      handle: getRandomString('sdk_unit_test_create_appointment_definition_handle'),
+      name: getRandomString('sdk_unit_test_create_appointment_definition_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+      ],
+      short_description: 'SDK unit test appointment definition',
+      buffer_before_minutes: 5,
+      buffer_after_minutes: 5,
+      min_lead_minutes: 0,
+      max_advance_days: 30,
+      slot_interval_minutes: 15,
+      allow_customer_booking: true,
+      requires_staff: false,
+      allow_waitlist: true,
+      allow_queue: false,
+      is_published: false
+    }
+
+    const definition: AppointmentDefinition = await createDefinitionWithRetry(payload).catch((err) => {
+      console.error('SDK Create Appointment Definition failed:', err)
+      throw new Error('SDK Create Appointment Definition failed')
+    })
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+    expect(definition).toBeDefined()
+    expect(definition.handle).toBe(payload.handle)
+    expect(definition.name).toBe(payload.name)
+    expect(definition.duration_minutes).toBe(payload.duration_minutes)
+    expect(definition.booking_type).toBe(payload.booking_type)
+    expect(definition.short_description).toBe(payload.short_description)
+    expect(definition.buffer_before_minutes).toBe(payload.buffer_before_minutes)
+    expect(definition.buffer_after_minutes).toBe(payload.buffer_after_minutes)
+    expect(definition.min_lead_minutes).toBe(payload.min_lead_minutes)
+    expect(definition.max_advance_days).toBe(payload.max_advance_days)
+    expect(definition.slot_interval_minutes).toBe(payload.slot_interval_minutes)
+    expect(definition.allow_customer_booking).toBe(payload.allow_customer_booking)
+    expect(definition.requires_staff).toBe(payload.requires_staff)
+    expect(definition.allow_waitlist).toBe(payload.allow_waitlist)
+    expect(definition.allow_queue).toBe(payload.allow_queue)
+    expect(definition.is_published).toBe(payload.is_published)
+  })
+
+  test('SDK Create Appointment Definition with inline normal hours', async () => {
+    const payload: CreateAppointmentDefinitionInput = {
+      handle: getRandomString('sdk_unit_test_create_appointment_definition_hours_handle'),
+      name: getRandomString('sdk_unit_test_create_appointment_definition_hours_name'),
+      duration_minutes: 45,
+      booking_type: 'approval_required',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' },
+        { day_of_week: 'TUE', available_from: '09:00', available_until: '17:00' }
+      ]
+    }
+
+    const definition: AppointmentDefinition = await createDefinitionWithRetry(payload).catch((err) => {
+      console.error('SDK Create Appointment Definition with inline normal hours failed:', err)
+      throw new Error('SDK Create Appointment Definition with inline normal hours failed')
+    })
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+    expect(definition).toBeDefined()
+    expect(definition.booking_type).toBe(payload.booking_type)
+    expect(definition.normal_hours).toBeDefined()
+    expect(definition.normal_hours?.length).toBe(2)
+    expect(definition.normal_hours?.[0]).toHaveProperty('day_of_week')
+    expect(definition.normal_hours?.[0]).toHaveProperty('available_from')
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/delete-appointment-definition.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/delete-appointment-definition.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+import { Omneo } from '@omneo'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+
+describe('Delete Appointment Definition', () => {
+  test('SDK Delete Appointment Definition', async () => {
+    const seeded = await seedAppointmentDefinition({
+      handle: getRandomString('sdk_unit_test_delete_appointment_definition_handle'),
+      name: getRandomString('sdk_unit_test_delete_appointment_definition_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+      ]
+    }).then(({ data }) => data)
+
+    await omneoClient.appointmentDefinitions.delete(seeded.id).catch((err) => {
+      console.error('SDK Delete Appointment Definition failed:', err)
+      throw new Error('SDK Delete Appointment Definition failed')
+    })
+
+    const response = await simpleOmneoRequest('GET', `/appointment-definitions/${seeded.id}`)
+    expect(response.status).toBe(404)
+  })
+})

--- a/src/tests/integration/omneo/appointment-definitions/get-appointment-definition.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/get-appointment-definition.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinition } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+
+describe('Get Appointment Definition', () => {
+  test('SDK Get Appointment Definition', async () => {
+    const payload = {
+      handle: getRandomString('sdk_unit_test_get_appointment_definition_handle'),
+      name: getRandomString('sdk_unit_test_get_appointment_definition_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+      ]
+    }
+    const seeded = await seedAppointmentDefinition(payload).then(({ data }) => data)
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+
+    const definition: AppointmentDefinition = await omneoClient.appointmentDefinitions.get(seeded.id).catch((err) => {
+      console.error('SDK Get Appointment Definition failed:', err)
+      throw new Error('SDK Get Appointment Definition failed')
+    })
+
+    expect(definition).toBeDefined()
+    expect(definition.id).toBe(seeded.id)
+    expect(definition.handle).toBe(payload.handle)
+    expect(definition.name).toBe(payload.name)
+    expect(definition.duration_minutes).toBe(payload.duration_minutes)
+    expect(definition.booking_type).toBe(payload.booking_type)
+    expect(definition).toHaveProperty('has_booking_questionnaire')
+    expect(definition).toHaveProperty('normal_hours')
+    expect(definition).toHaveProperty('locations')
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/get-definition-questions.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/get-definition-questions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+
+describe('Get Appointment Definition Questions', () => {
+  test('SDK Get Appointment Definition Questions', async () => {
+    const seeded = await seedAppointmentDefinition({
+      handle: getRandomString('sdk_unit_test_definition_questions_handle'),
+      name: getRandomString('sdk_unit_test_definition_questions_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+      ]
+    }).then(({ data }) => data)
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+
+    const questions = await omneoClient.appointmentDefinitions.getQuestions(seeded.id).catch((err) => {
+      console.error('SDK Get Appointment Definition Questions failed:', err)
+      throw new Error('SDK Get Appointment Definition Questions failed')
+    })
+
+    expect(questions).toBeDefined()
+    expect(questions).toHaveProperty('questionnaire')
+    expect(questions).toHaveProperty('questions')
+    // Definition has no booking questionnaire, so the form is empty
+    expect(questions.questionnaire).toBeNull()
+    expect(Array.isArray(questions.questions)).toBe(true)
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/list-appointment-definitions.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/list-appointment-definitions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinitionResponse } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+
+describe('List Appointment Definitions', () => {
+  test('SDK List Appointment Definitions', async () => {
+    const payload = {
+      handle: getRandomString('sdk_unit_test_list_appointment_definitions_handle'),
+      name: getRandomString('sdk_unit_test_list_appointment_definitions_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+      ]
+    }
+    const seeded = await seedAppointmentDefinition(payload).then(({ data }) => data)
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+
+    const response: AppointmentDefinitionResponse = await omneoClient.appointmentDefinitions.list({
+      'filter[handle]': payload.handle
+    }).catch((err) => {
+      console.error('SDK List Appointment Definitions failed:', err)
+      throw new Error('SDK List Appointment Definitions failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.length).toBe(1)
+    expect(response.data[0].id).toBe(seeded.id)
+    expect(response.data[0].handle).toBe(payload.handle)
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/manage-definition-locations.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/manage-definition-locations.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinitionLocation } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+let definitionID: number
+let locationID: number
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  locationID = locations[0].id
+
+  const seeded = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_definition_locations_handle'),
+    name: getRandomString('sdk_unit_test_definition_locations_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: [
+      { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+    ]
+  }).then(({ data }) => data)
+  definitionID = seeded.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+})
+
+describe('Manage Appointment Definition Locations', () => {
+  let definitionLocation: AppointmentDefinitionLocation
+
+  test('SDK Create Appointment Definition Location', async () => {
+    definitionLocation = await omneoClient.appointmentDefinitions.locations.create(definitionID, {
+      location_id: locationID,
+      is_active: true
+    }).catch((err) => {
+      console.error('SDK Create Appointment Definition Location failed:', err)
+      throw new Error('SDK Create Appointment Definition Location failed')
+    })
+
+    expect(definitionLocation).toBeDefined()
+    expect(definitionLocation.location_id).toBe(locationID)
+    expect(definitionLocation.is_active).toBe(true)
+    expect(definitionLocation.appointment_definition_id).toBe(definitionID)
+  })
+
+  test('SDK List Appointment Definition Locations', async () => {
+    const definitionLocations = await omneoClient.appointmentDefinitions.locations.list(definitionID).catch((err) => {
+      console.error('SDK List Appointment Definition Locations failed:', err)
+      throw new Error('SDK List Appointment Definition Locations failed')
+    })
+
+    expect(Array.isArray(definitionLocations)).toBe(true)
+    expect(definitionLocations.find((location) => location.id === definitionLocation.id)).toBeDefined()
+  })
+
+  // API quirk: get and delete resolve the attachment row id, update resolves
+  // the location id
+  test('SDK Get Appointment Definition Location', async () => {
+    const found = await omneoClient.appointmentDefinitions.locations.get(definitionID, definitionLocation.id).catch((err) => {
+      console.error('SDK Get Appointment Definition Location failed:', err)
+      throw new Error('SDK Get Appointment Definition Location failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(definitionLocation.id)
+    expect(found.location_id).toBe(locationID)
+  })
+
+  test('SDK Update Appointment Definition Location', async () => {
+    const updated = await omneoClient.appointmentDefinitions.locations.update(definitionID, locationID, {
+      is_active: false
+    }).catch((err) => {
+      console.error('SDK Update Appointment Definition Location failed:', err)
+      throw new Error('SDK Update Appointment Definition Location failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.location_id).toBe(locationID)
+    expect(updated.is_active).toBe(false)
+  })
+
+  test('SDK Delete Appointment Definition Location', async () => {
+    await omneoClient.appointmentDefinitions.locations.delete(definitionID, definitionLocation.id).catch((err) => {
+      console.error('SDK Delete Appointment Definition Location failed:', err)
+      throw new Error('SDK Delete Appointment Definition Location failed')
+    })
+
+    const definitionLocations = await omneoClient.appointmentDefinitions.locations.list(definitionID)
+    expect(definitionLocations.find((location) => location.id === definitionLocation.id)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/manage-definition-normal-hours.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/manage-definition-normal-hours.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinitionNormalHour } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+let definitionID: number
+
+beforeAll(async () => {
+  const seeded = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_definition_normal_hours_handle'),
+    name: getRandomString('sdk_unit_test_definition_normal_hours_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: [
+      { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+    ]
+  }).then(({ data }) => data)
+  definitionID = seeded.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+})
+
+describe('Manage Appointment Definition Normal Hours', () => {
+  let normalHour: AppointmentDefinitionNormalHour
+
+  test('SDK Create Appointment Definition Normal Hour', async () => {
+    const payload = {
+      day_of_week: 'WED' as const,
+      available_from: '09:00',
+      available_until: '17:00'
+    }
+
+    normalHour = await omneoClient.appointmentDefinitions.normalHours.create(definitionID, payload).catch((err) => {
+      console.error('SDK Create Appointment Definition Normal Hour failed:', err)
+      throw new Error('SDK Create Appointment Definition Normal Hour failed')
+    })
+
+    expect(normalHour).toBeDefined()
+    expect(normalHour.day_of_week).toBe(payload.day_of_week)
+    expect(normalHour.appointment_definition_id).toBe(definitionID)
+  })
+
+  test('SDK List Appointment Definition Normal Hours', async () => {
+    const normalHours = await omneoClient.appointmentDefinitions.normalHours.list(definitionID).catch((err) => {
+      console.error('SDK List Appointment Definition Normal Hours failed:', err)
+      throw new Error('SDK List Appointment Definition Normal Hours failed')
+    })
+
+    expect(Array.isArray(normalHours)).toBe(true)
+    expect(normalHours.find((hour) => hour.id === normalHour.id)).toBeDefined()
+  })
+
+  test('SDK Get Appointment Definition Normal Hour', async () => {
+    const found = await omneoClient.appointmentDefinitions.normalHours.get(definitionID, normalHour.id).catch((err) => {
+      console.error('SDK Get Appointment Definition Normal Hour failed:', err)
+      throw new Error('SDK Get Appointment Definition Normal Hour failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(normalHour.id)
+    expect(found.day_of_week).toBe(normalHour.day_of_week)
+  })
+
+  test('SDK Update Appointment Definition Normal Hour', async () => {
+    const updated = await omneoClient.appointmentDefinitions.normalHours.update(definitionID, normalHour.id, {
+      available_until: '18:00'
+    }).catch((err) => {
+      console.error('SDK Update Appointment Definition Normal Hour failed:', err)
+      throw new Error('SDK Update Appointment Definition Normal Hour failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.id).toBe(normalHour.id)
+    expect(updated.available_until).toContain('18:00')
+  })
+
+  test('SDK Delete Appointment Definition Normal Hour', async () => {
+    await omneoClient.appointmentDefinitions.normalHours.delete(definitionID, normalHour.id).catch((err) => {
+      console.error('SDK Delete Appointment Definition Normal Hour failed:', err)
+      throw new Error('SDK Delete Appointment Definition Normal Hour failed')
+    })
+
+    const normalHours = await omneoClient.appointmentDefinitions.normalHours.list(definitionID)
+    expect(normalHours.find((hour) => hour.id === normalHour.id)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/manage-definition-special-hours.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/manage-definition-special-hours.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinitionSpecialHour } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+let definitionID: number
+
+beforeAll(async () => {
+  const seeded = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_definition_special_hours_handle'),
+    name: getRandomString('sdk_unit_test_definition_special_hours_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: [
+      { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+    ]
+  }).then(({ data }) => data)
+  definitionID = seeded.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+})
+
+describe('Manage Appointment Definition Special Hours', () => {
+  let specialHour: AppointmentDefinitionSpecialHour
+
+  test('SDK Create Appointment Definition Special Hour', async () => {
+    const payload = {
+      name: getRandomString('sdk_unit_test_special_hour_name'),
+      start_at: '2026-12-25',
+      end_at: '2026-12-25',
+      is_repeating: false,
+      available_from: '10:00',
+      available_until: '14:00'
+    }
+
+    specialHour = await omneoClient.appointmentDefinitions.specialHours.create(definitionID, payload).catch((err) => {
+      console.error('SDK Create Appointment Definition Special Hour failed:', err)
+      throw new Error('SDK Create Appointment Definition Special Hour failed')
+    })
+
+    expect(specialHour).toBeDefined()
+    expect(specialHour.name).toBe(payload.name)
+    expect(specialHour.is_repeating).toBe(payload.is_repeating)
+    expect(specialHour.appointment_definition_id).toBe(definitionID)
+  })
+
+  test('SDK List Appointment Definition Special Hours', async () => {
+    const specialHours = await omneoClient.appointmentDefinitions.specialHours.list(definitionID).catch((err) => {
+      console.error('SDK List Appointment Definition Special Hours failed:', err)
+      throw new Error('SDK List Appointment Definition Special Hours failed')
+    })
+
+    expect(Array.isArray(specialHours)).toBe(true)
+    expect(specialHours.find((hour) => hour.id === specialHour.id)).toBeDefined()
+  })
+
+  test('SDK Get Appointment Definition Special Hour', async () => {
+    const found = await omneoClient.appointmentDefinitions.specialHours.get(definitionID, specialHour.id).catch((err) => {
+      console.error('SDK Get Appointment Definition Special Hour failed:', err)
+      throw new Error('SDK Get Appointment Definition Special Hour failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(specialHour.id)
+    expect(found.name).toBe(specialHour.name)
+  })
+
+  test('SDK Update Appointment Definition Special Hour', async () => {
+    const updated = await omneoClient.appointmentDefinitions.specialHours.update(definitionID, specialHour.id, {
+      available_until: '15:00'
+    }).catch((err) => {
+      console.error('SDK Update Appointment Definition Special Hour failed:', err)
+      throw new Error('SDK Update Appointment Definition Special Hour failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.id).toBe(specialHour.id)
+    expect(updated.available_until).toContain('15:00')
+  })
+
+  test('SDK Delete Appointment Definition Special Hour', async () => {
+    await omneoClient.appointmentDefinitions.specialHours.delete(definitionID, specialHour.id).catch((err) => {
+      console.error('SDK Delete Appointment Definition Special Hour failed:', err)
+      throw new Error('SDK Delete Appointment Definition Special Hour failed')
+    })
+
+    const specialHours = await omneoClient.appointmentDefinitions.specialHours.list(definitionID)
+    expect(specialHours.find((hour) => hour.id === specialHour.id)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/manage-definition-staff.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/manage-definition-staff.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let staffProfileID: string
+
+beforeAll(async () => {
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Staff Test',
+    email: `${getRandomString('sdk_unit_test_definition_staff')}@omneodemo.com`
+  }).then(({ data }) => data)
+  staffProfileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  // staff_ids must be non-empty when use_staff_from_location is false and
+  // requires_staff is true, so seed the definition with a different profile
+  // and let the tests attach staffProfileID through the SDK
+  const seedStaffProfile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Seed Staff',
+    email: `${getRandomString('sdk_unit_test_definition_seed_staff')}@omneodemo.com`
+  }).then(({ data }) => data)
+  CREATED_PROFILE_IDS.push(seedStaffProfile.id)
+
+  const seeded = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_definition_staff_handle'),
+    name: getRandomString('sdk_unit_test_definition_staff_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    requires_staff: true,
+    use_staff_from_location: false,
+    staff_ids: [seedStaffProfile.id],
+    normal_hours: [
+      { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+    ]
+  }).then(({ data }) => data)
+  definitionID = seeded.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+})
+
+describe('Manage Appointment Definition Staff', () => {
+  let staffRowID: number
+
+  test('SDK Create Appointment Definition Staff', async () => {
+    const staffRow = await omneoClient.appointmentDefinitions.staff.create(definitionID, {
+      staff_id: staffProfileID,
+      is_active: true
+    }).catch((err) => {
+      console.error('SDK Create Appointment Definition Staff failed:', err)
+      throw new Error('SDK Create Appointment Definition Staff failed')
+    })
+    staffRowID = staffRow.id
+
+    expect(staffRow).toBeDefined()
+    expect(staffRow.staff_id).toBe(staffProfileID)
+    expect(staffRow.is_active).toBe(true)
+    expect(staffRow.appointment_definition_id).toBe(definitionID)
+  })
+
+  test('SDK List Appointment Definition Staff', async () => {
+    const staffRows = await omneoClient.appointmentDefinitions.staff.list(definitionID).catch((err) => {
+      console.error('SDK List Appointment Definition Staff failed:', err)
+      throw new Error('SDK List Appointment Definition Staff failed')
+    })
+
+    expect(Array.isArray(staffRows)).toBe(true)
+    expect(staffRows.find((row) => row.id === staffRowID)).toBeDefined()
+  })
+
+  test('SDK Get Appointment Definition Staff', async () => {
+    const found = await omneoClient.appointmentDefinitions.staff.get(definitionID, staffRowID).catch((err) => {
+      console.error('SDK Get Appointment Definition Staff failed:', err)
+      throw new Error('SDK Get Appointment Definition Staff failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(staffRowID)
+    expect(found.staff_id).toBe(staffProfileID)
+  })
+
+  test('SDK Update Appointment Definition Staff', async () => {
+    const updated = await omneoClient.appointmentDefinitions.staff.update(definitionID, staffRowID, {
+      is_active: false
+    }).catch((err) => {
+      console.error('SDK Update Appointment Definition Staff failed:', err)
+      throw new Error('SDK Update Appointment Definition Staff failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.id).toBe(staffRowID)
+    expect(updated.is_active).toBe(false)
+  })
+
+  test('SDK Delete Appointment Definition Staff', async () => {
+    await omneoClient.appointmentDefinitions.staff.delete(definitionID, staffRowID).catch((err) => {
+      console.error('SDK Delete Appointment Definition Staff failed:', err)
+      throw new Error('SDK Delete Appointment Definition Staff failed')
+    })
+
+    const staffRows = await omneoClient.appointmentDefinitions.staff.list(definitionID)
+    expect(staffRows.find((row) => row.id === staffRowID)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-definitions/update-appointment-definition.test.ts
+++ b/src/tests/integration/omneo/appointment-definitions/update-appointment-definition.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentDefinition } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+
+describe('Update Appointment Definition', () => {
+  test('SDK Update Appointment Definition', async () => {
+    const seeded = await seedAppointmentDefinition({
+      handle: getRandomString('sdk_unit_test_update_appointment_definition_handle'),
+      name: getRandomString('sdk_unit_test_update_appointment_definition_name'),
+      duration_minutes: 30,
+      booking_type: 'instant',
+      normal_hours: [
+        { day_of_week: 'MON', available_from: '09:00', available_until: '17:00' }
+      ],
+      is_published: false
+    }).then(({ data }) => data)
+    CREATED_APPOINTMENT_DEFINITION_IDS.push(seeded.id)
+
+    const payload = {
+      name: getRandomString('sdk_unit_test_update_appointment_definition_new_name'),
+      duration_minutes: 45,
+      is_published: true
+    }
+
+    const definition: AppointmentDefinition = await omneoClient.appointmentDefinitions.update(seeded.id, payload).catch((err) => {
+      console.error('SDK Update Appointment Definition failed:', err)
+      throw new Error('SDK Update Appointment Definition failed')
+    })
+
+    expect(definition).toBeDefined()
+    expect(definition.id).toBe(seeded.id)
+    expect(definition.name).toBe(payload.name)
+    expect(definition.duration_minutes).toBe(payload.duration_minutes)
+    expect(definition.is_published).toBe(payload.is_published)
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-queues/create-appointment-queue.test.ts
+++ b/src/tests/integration/omneo/appointment-queues/create-appointment-queue.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentQueue, CreateAppointmentQueueInput } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_QUEUE_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let locationID: number
+let profileID: string
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  locationID = locations[0].id
+
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Queue Test',
+    email: `${getRandomString('sdk_unit_test_create_queue')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_create_queue_handle'),
+    name: getRandomString('sdk_unit_test_create_queue_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    allow_walk_in: true,
+    allow_queue: true,
+    is_published: true,
+    location_ids: [locationID]
+  }).then(({ data }) => data)
+  definitionID = definition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+})
+
+describe('Create Appointment Queue', () => {
+  test('SDK Create Appointment Queue with a profile', async () => {
+    const payload: CreateAppointmentQueueInput = {
+      appointment_definition_id: definitionID,
+      location_id: locationID,
+      profile_id: profileID,
+      notes: 'SDK unit test walk-in'
+    }
+
+    const queueEntry: AppointmentQueue = await omneoClient.appointmentQueues.create(payload).catch((err) => {
+      console.error('SDK Create Appointment Queue failed:', err)
+      throw new Error('SDK Create Appointment Queue failed')
+    })
+    CREATED_APPOINTMENT_QUEUE_IDS.push(queueEntry.id)
+
+    expect(queueEntry).toBeDefined()
+    expect(queueEntry.appointment_definition_id).toBe(definitionID)
+    expect(queueEntry.location_id).toBe(locationID)
+    expect(queueEntry.profile_id).toBe(profileID)
+    expect(queueEntry.status).toBe('waiting')
+    expect(queueEntry.appointment_id).toBeNull()
+    expect(queueEntry.notes).toBe(payload.notes)
+  })
+
+  test('SDK Create Appointment Queue anonymous walk-in', async () => {
+    const payload: CreateAppointmentQueueInput = {
+      appointment_definition_id: definitionID,
+      location_id: locationID
+    }
+
+    const queueEntry: AppointmentQueue = await omneoClient.appointmentQueues.create(payload).catch((err) => {
+      console.error('SDK Create Appointment Queue (anonymous) failed:', err)
+      throw new Error('SDK Create Appointment Queue (anonymous) failed')
+    })
+    CREATED_APPOINTMENT_QUEUE_IDS.push(queueEntry.id)
+
+    expect(queueEntry).toBeDefined()
+    expect(queueEntry.profile_id).toBeNull()
+    expect(queueEntry.profile).toBeNull()
+    expect(queueEntry.status).toBe('waiting')
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_QUEUE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-queues/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Queue ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Queue ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-queues/manage-appointment-queue.test.ts
+++ b/src/tests/integration/omneo/appointment-queues/manage-appointment-queue.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentQueue, AppointmentQueueResponse } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_QUEUE_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+let definitionID: number
+let queueEntryID: number
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_manage_queue_handle'),
+    name: getRandomString('sdk_unit_test_manage_queue_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    allow_walk_in: true,
+    allow_queue: true,
+    is_published: true,
+    location_ids: [locations[0].id]
+  }).then(({ data }) => data)
+  definitionID = definition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  const queueEntry = await simpleOmneoRequest('POST', '/appointment-queues', {
+    appointment_definition_id: definitionID,
+    location_id: locations[0].id
+  }).then(({ data }) => data)
+  queueEntryID = queueEntry.id
+  CREATED_APPOINTMENT_QUEUE_IDS.push(queueEntry.id)
+})
+
+describe('Manage Appointment Queue', () => {
+  test('SDK Get Appointment Queue', async () => {
+    const queueEntry: AppointmentQueue = await omneoClient.appointmentQueues.get(queueEntryID).catch((err) => {
+      console.error('SDK Get Appointment Queue failed:', err)
+      throw new Error('SDK Get Appointment Queue failed')
+    })
+
+    expect(queueEntry).toBeDefined()
+    expect(queueEntry.id).toBe(queueEntryID)
+    expect(queueEntry.appointment_definition_id).toBe(definitionID)
+    expect(queueEntry.status).toBe('waiting')
+  })
+
+  test('SDK List Appointment Queues', async () => {
+    const response: AppointmentQueueResponse = await omneoClient.appointmentQueues.list({
+      'filter[appointment_definition_id]': definitionID
+    }).catch((err) => {
+      console.error('SDK List Appointment Queues failed:', err)
+      throw new Error('SDK List Appointment Queues failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((entry) => entry.id === queueEntryID)).toBeDefined()
+  })
+
+  test('SDK Update Appointment Queue through its lifecycle', async () => {
+    const called: AppointmentQueue = await omneoClient.appointmentQueues.update(queueEntryID, {
+      status: 'called'
+    }).catch((err) => {
+      console.error('SDK Update Appointment Queue (called) failed:', err)
+      throw new Error('SDK Update Appointment Queue (called) failed')
+    })
+    expect(called.status).toBe('called')
+
+    const served: AppointmentQueue = await omneoClient.appointmentQueues.update(queueEntryID, {
+      status: 'served'
+    }).catch((err) => {
+      console.error('SDK Update Appointment Queue (served) failed:', err)
+      throw new Error('SDK Update Appointment Queue (served) failed')
+    })
+    expect(served.status).toBe('served')
+  })
+
+  test('SDK Delete Appointment Queue', async () => {
+    await omneoClient.appointmentQueues.delete(queueEntryID).catch((err) => {
+      console.error('SDK Delete Appointment Queue failed:', err)
+      throw new Error('SDK Delete Appointment Queue failed')
+    })
+
+    const response = await simpleOmneoRequest('GET', `/appointment-queues/${queueEntryID}`)
+    expect(response.status).toBe(404)
+    CREATED_APPOINTMENT_QUEUE_IDS.length = 0
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_QUEUE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-queues/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Queue ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Queue ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-waitlists/create-appointment-waitlist.test.ts
+++ b/src/tests/integration/omneo/appointment-waitlists/create-appointment-waitlist.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentWaitlist, CreateAppointmentWaitlistInput } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_WAITLIST_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let locationID: number
+let profileID: string
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  locationID = locations[0].id
+
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Waitlist Test',
+    email: `${getRandomString('sdk_unit_test_create_waitlist')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_create_waitlist_handle'),
+    name: getRandomString('sdk_unit_test_create_waitlist_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    allow_waitlist: true,
+    is_published: true,
+    location_ids: [locationID]
+  }).then(({ data }) => data)
+  definitionID = definition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+})
+
+describe('Create Appointment Waitlist', () => {
+  test('SDK Create Appointment Waitlist', async () => {
+    const payload: CreateAppointmentWaitlistInput = {
+      appointment_definition_id: definitionID,
+      profile_id: profileID,
+      location_id: locationID,
+      notes: 'SDK unit test waitlist entry'
+    }
+
+    const waitlistEntry: AppointmentWaitlist = await omneoClient.appointmentWaitlists.create(payload).catch((err) => {
+      console.error('SDK Create Appointment Waitlist failed:', err)
+      throw new Error('SDK Create Appointment Waitlist failed')
+    })
+    CREATED_APPOINTMENT_WAITLIST_IDS.push(waitlistEntry.id)
+
+    expect(waitlistEntry).toBeDefined()
+    expect(waitlistEntry.appointment_definition_id).toBe(definitionID)
+    expect(waitlistEntry.profile_id).toBe(profileID)
+    expect(waitlistEntry.location_id).toBe(locationID)
+    expect(waitlistEntry.status).toBe('active')
+    expect(waitlistEntry.appointment_id).toBeNull()
+    expect(waitlistEntry.notes).toBe(payload.notes)
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_WAITLIST_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-waitlists/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Waitlist ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Waitlist ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointment-waitlists/manage-appointment-waitlist.test.ts
+++ b/src/tests/integration/omneo/appointment-waitlists/manage-appointment-waitlist.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentWaitlist, AppointmentWaitlistResponse } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_WAITLIST_IDS: number[] = []
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let locationID: number
+let profileID: string
+let waitlistEntryID: number
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  locationID = locations[0].id
+
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Waitlist Test',
+    email: `${getRandomString('sdk_unit_test_manage_waitlist')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_manage_waitlist_handle'),
+    name: getRandomString('sdk_unit_test_manage_waitlist_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    allow_waitlist: true,
+    is_published: true,
+    location_ids: [locationID]
+  }).then(({ data }) => data)
+  definitionID = definition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  const waitlistEntry = await simpleOmneoRequest('POST', '/appointment-waitlists', {
+    appointment_definition_id: definitionID,
+    profile_id: profileID,
+    location_id: locationID
+  }).then(({ data }) => data)
+  waitlistEntryID = waitlistEntry.id
+  CREATED_APPOINTMENT_WAITLIST_IDS.push(waitlistEntry.id)
+})
+
+describe('Manage Appointment Waitlist', () => {
+  test('SDK Get Appointment Waitlist', async () => {
+    const waitlistEntry: AppointmentWaitlist = await omneoClient.appointmentWaitlists.get(waitlistEntryID).catch((err) => {
+      console.error('SDK Get Appointment Waitlist failed:', err)
+      throw new Error('SDK Get Appointment Waitlist failed')
+    })
+
+    expect(waitlistEntry).toBeDefined()
+    expect(waitlistEntry.id).toBe(waitlistEntryID)
+    expect(waitlistEntry.appointment_definition_id).toBe(definitionID)
+    expect(waitlistEntry.status).toBe('active')
+  })
+
+  test('SDK List Appointment Waitlists', async () => {
+    const response: AppointmentWaitlistResponse = await omneoClient.appointmentWaitlists.list({
+      'filter[appointment_definition_id]': definitionID
+    }).catch((err) => {
+      console.error('SDK List Appointment Waitlists failed:', err)
+      throw new Error('SDK List Appointment Waitlists failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((entry) => entry.id === waitlistEntryID)).toBeDefined()
+  })
+
+  test('SDK Update Appointment Waitlist to fulfilled with an appointment', async () => {
+    const appointment = await simpleOmneoRequest('POST', '/appointments', {
+      appointment_definition_id: definitionID,
+      profile_id: profileID,
+      location_id: locationID,
+      scheduled_start_at: `${futureDate(3)} 10:00:00`,
+      scheduled_end_at: `${futureDate(3)} 10:30:00`,
+      timezone: 'Australia/Melbourne'
+    }).then(({ data }) => data)
+    CREATED_APPOINTMENT_IDS.push(appointment.id)
+
+    const waitlistEntry: AppointmentWaitlist = await omneoClient.appointmentWaitlists.update(waitlistEntryID, {
+      status: 'fulfilled',
+      appointment_id: appointment.id
+    }).catch((err) => {
+      console.error('SDK Update Appointment Waitlist failed:', err)
+      throw new Error('SDK Update Appointment Waitlist failed')
+    })
+
+    expect(waitlistEntry).toBeDefined()
+    expect(waitlistEntry.status).toBe('fulfilled')
+    expect(waitlistEntry.appointment_id).toBe(appointment.id)
+  })
+
+  test('SDK Delete Appointment Waitlist', async () => {
+    await omneoClient.appointmentWaitlists.delete(waitlistEntryID).catch((err) => {
+      console.error('SDK Delete Appointment Waitlist failed:', err)
+      throw new Error('SDK Delete Appointment Waitlist failed')
+    })
+
+    const response = await simpleOmneoRequest('GET', `/appointment-waitlists/${waitlistEntryID}`)
+    expect(response.status).toBe(404)
+    CREATED_APPOINTMENT_WAITLIST_IDS.length = 0
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_WAITLIST_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-waitlists/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Waitlist ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Waitlist ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointments/create-appointment.test.ts
+++ b/src/tests/integration/omneo/appointments/create-appointment.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { Appointment, CreateAppointmentInput } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let instantDefinitionID: number
+let approvalDefinitionID: number
+let locationID: number
+let profileID: string
+
+const ALL_WEEK_HOURS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'].map((day) => {
+  return { day_of_week: day, available_from: '09:00', available_until: '17:00' }
+})
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  locationID = locations[0].id
+
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Appointment Test',
+    email: `${getRandomString('sdk_unit_test_create_appointment')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const instantDefinition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_create_appointment_instant_handle'),
+    name: getRandomString('sdk_unit_test_create_appointment_instant_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locationID],
+    normal_hours: ALL_WEEK_HOURS
+  }).then(({ data }) => data)
+  instantDefinitionID = instantDefinition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(instantDefinition.id)
+
+  const approvalDefinition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_create_appointment_approval_handle'),
+    name: getRandomString('sdk_unit_test_create_appointment_approval_name'),
+    duration_minutes: 30,
+    booking_type: 'approval_required',
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locationID],
+    normal_hours: ALL_WEEK_HOURS
+  }).then(({ data }) => data)
+  approvalDefinitionID = approvalDefinition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(approvalDefinition.id)
+})
+
+describe('Create Appointment', () => {
+  test('SDK Create Appointment against an instant definition is confirmed', async () => {
+    const payload: CreateAppointmentInput = {
+      appointment_definition_id: instantDefinitionID,
+      profile_id: profileID,
+      location_id: locationID,
+      scheduled_start_at: `${futureDate(3)} 10:00:00`,
+      scheduled_end_at: `${futureDate(3)} 10:30:00`,
+      timezone: 'Australia/Melbourne',
+      notes: 'SDK unit test appointment'
+    }
+
+    const appointment: Appointment = await omneoClient.appointments.create(payload).catch((err) => {
+      console.error('SDK Create Appointment failed:', err)
+      throw new Error('SDK Create Appointment failed')
+    })
+    CREATED_APPOINTMENT_IDS.push(appointment.id)
+
+    expect(appointment).toBeDefined()
+    expect(appointment.appointment_definition_id).toBe(instantDefinitionID)
+    expect(appointment.profile_id).toBe(profileID)
+    expect(appointment.location_id).toBe(locationID)
+    expect(appointment.timezone).toBe(payload.timezone)
+    expect(appointment.notes).toBe(payload.notes)
+    expect(appointment.status).toBe('confirmed')
+    expect(appointment.confirmed_at).not.toBeNull()
+    // Scheduled times are sent in the request timezone and returned in UTC
+    expect(appointment.scheduled_start_at).toBeDefined()
+    expect(new Date(appointment.scheduled_start_at).getTime()).not.toBeNaN()
+  })
+
+  test('SDK Create Appointment against an approval_required definition is requested', async () => {
+    const payload: CreateAppointmentInput = {
+      appointment_definition_id: approvalDefinitionID,
+      profile_id: profileID,
+      location_id: locationID,
+      scheduled_start_at: `${futureDate(4)} 11:00:00`,
+      scheduled_end_at: `${futureDate(4)} 11:30:00`,
+      timezone: 'Australia/Melbourne'
+    }
+
+    const appointment: Appointment = await omneoClient.appointments.create(payload).catch((err) => {
+      console.error('SDK Create Appointment (approval) failed:', err)
+      throw new Error('SDK Create Appointment (approval) failed')
+    })
+    CREATED_APPOINTMENT_IDS.push(appointment.id)
+
+    expect(appointment).toBeDefined()
+    expect(appointment.status).toBe('requested')
+    expect(appointment.confirmed_at).toBeNull()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointments/delete-appointment.test.ts
+++ b/src/tests/integration/omneo/appointments/delete-appointment.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let appointmentID: number
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Appointment Test',
+    email: `${getRandomString('sdk_unit_test_delete_appointment')}@omneodemo.com`
+  }).then(({ data }) => data)
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_delete_appointment_handle'),
+    name: getRandomString('sdk_unit_test_delete_appointment_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locations[0].id]
+  }).then(({ data }) => data)
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  const appointment = await simpleOmneoRequest('POST', '/appointments', {
+    appointment_definition_id: definition.id,
+    profile_id: profile.id,
+    location_id: locations[0].id,
+    scheduled_start_at: `${futureDate(3)} 10:00:00`,
+    scheduled_end_at: `${futureDate(3)} 10:30:00`,
+    timezone: 'Australia/Melbourne'
+  }).then(({ data }) => data)
+  appointmentID = appointment.id
+})
+
+describe('Delete Appointment', () => {
+  test('SDK Delete Appointment', async () => {
+    await omneoClient.appointments.delete(appointmentID).catch((err) => {
+      console.error('SDK Delete Appointment failed:', err)
+      throw new Error('SDK Delete Appointment failed')
+    })
+
+    const response = await simpleOmneoRequest('GET', `/appointments/${appointmentID}`)
+    expect(response.status).toBe(404)
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointments/get-appointment.test.ts
+++ b/src/tests/integration/omneo/appointments/get-appointment.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { Appointment } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let seededAppointment: any
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Appointment Test',
+    email: `${getRandomString('sdk_unit_test_get_appointment')}@omneodemo.com`
+  }).then(({ data }) => data)
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_get_appointment_handle'),
+    name: getRandomString('sdk_unit_test_get_appointment_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locations[0].id]
+  }).then(({ data }) => data)
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  seededAppointment = await simpleOmneoRequest('POST', '/appointments', {
+    appointment_definition_id: definition.id,
+    profile_id: profile.id,
+    location_id: locations[0].id,
+    scheduled_start_at: `${futureDate(3)} 10:00:00`,
+    scheduled_end_at: `${futureDate(3)} 10:30:00`,
+    timezone: 'Australia/Melbourne'
+  }).then(({ data }) => data)
+  CREATED_APPOINTMENT_IDS.push(seededAppointment.id)
+})
+
+describe('Get Appointment', () => {
+  test('SDK Get Appointment', async () => {
+    const appointment: Appointment = await omneoClient.appointments.get(seededAppointment.id).catch((err) => {
+      console.error('SDK Get Appointment failed:', err)
+      throw new Error('SDK Get Appointment failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(appointment.id).toBe(seededAppointment.id)
+    expect(appointment.profile_id).toBe(seededAppointment.profile_id)
+    expect(appointment.appointment_definition_id).toBe(seededAppointment.appointment_definition_id)
+    expect(appointment).toHaveProperty('status')
+    expect(appointment).toHaveProperty('scheduled_start_at')
+    expect(appointment).toHaveProperty('answers')
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointments/link-appointment.test.ts
+++ b/src/tests/integration/omneo/appointments/link-appointment.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { Appointment } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let appointmentID: number
+let linkedProfileID: string
+let secondLinkedProfileID: string
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Appointment Test',
+    email: `${getRandomString('sdk_unit_test_link_appointment')}@omneodemo.com`
+  }).then(({ data }) => data)
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const secondProfile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Linked Attendee',
+    email: `${getRandomString('sdk_unit_test_link_appointment_attendee')}@omneodemo.com`
+  }).then(({ data }) => data)
+  linkedProfileID = secondProfile.id
+  CREATED_PROFILE_IDS.push(secondProfile.id)
+
+  const thirdProfile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Second Attendee',
+    email: `${getRandomString('sdk_unit_test_link_appointment_attendee_two')}@omneodemo.com`
+  }).then(({ data }) => data)
+  secondLinkedProfileID = thirdProfile.id
+  CREATED_PROFILE_IDS.push(thirdProfile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_link_appointment_handle'),
+    name: getRandomString('sdk_unit_test_link_appointment_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locations[0].id]
+  }).then(({ data }) => data)
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  const appointment = await simpleOmneoRequest('POST', '/appointments', {
+    appointment_definition_id: definition.id,
+    profile_id: profile.id,
+    location_id: locations[0].id,
+    scheduled_start_at: `${futureDate(3)} 10:00:00`,
+    scheduled_end_at: `${futureDate(3)} 10:30:00`,
+    timezone: 'Australia/Melbourne'
+  }).then(({ data }) => data)
+  appointmentID = appointment.id
+  CREATED_APPOINTMENT_IDS.push(appointment.id)
+})
+
+describe('Link Appointment', () => {
+  test('SDK Link Appointment to a profile', async () => {
+    const appointment: Appointment = await omneoClient.appointments.link(appointmentID, {
+      type: 'profile',
+      id: linkedProfileID
+    }).catch((err) => {
+      console.error('SDK Link Appointment failed:', err)
+      throw new Error('SDK Link Appointment failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(Array.isArray(appointment.links)).toBe(true)
+    expect(appointment.links?.find((link) => link.type === 'profile' && link.target_id === linkedProfileID)).toBeDefined()
+  })
+
+  test('SDK Link Appointment is idempotent', async () => {
+    const appointment: Appointment = await omneoClient.appointments.link(appointmentID, {
+      type: 'profile',
+      id: linkedProfileID
+    }).catch((err) => {
+      console.error('SDK Link Appointment (repeat) failed:', err)
+      throw new Error('SDK Link Appointment (repeat) failed')
+    })
+
+    const matchingLinks = appointment.links?.filter((link) => link.type === 'profile' && link.target_id === linkedProfileID)
+    expect(matchingLinks?.length).toBe(1)
+  })
+
+  test('SDK Unlink Appointment', async () => {
+    await omneoClient.appointments.unlink(appointmentID, {
+      type: 'profile',
+      id: linkedProfileID
+    }).catch((err) => {
+      console.error('SDK Unlink Appointment failed:', err)
+      throw new Error('SDK Unlink Appointment failed')
+    })
+
+    // Reads never include links, so verify the removal through a follow-up
+    // link response, which returns the full current links array
+    const appointment: Appointment = await omneoClient.appointments.link(appointmentID, {
+      type: 'profile',
+      id: secondLinkedProfileID
+    }).catch((err) => {
+      console.error('SDK Link Appointment (verify unlink) failed:', err)
+      throw new Error('SDK Link Appointment (verify unlink) failed')
+    })
+
+    expect(appointment.links?.find((link) => link.type === 'profile' && link.target_id === linkedProfileID)).toBeUndefined()
+    expect(appointment.links?.find((link) => link.type === 'profile' && link.target_id === secondLinkedProfileID)).toBeDefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointments/link-appointment.test.ts
+++ b/src/tests/integration/omneo/appointments/link-appointment.test.ts
@@ -20,27 +20,29 @@ const futureDate = (daysAhead: number): string => {
 }
 
 beforeAll(async () => {
-  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
-  const profile = await simpleOmneoRequest('POST', '/profiles', {
-    first_name: 'SDK',
-    last_name: 'Appointment Test',
-    email: `${getRandomString('sdk_unit_test_link_appointment')}@omneodemo.com`
-  }).then(({ data }) => data)
+  // Seeded in parallel — six serial round trips push this hook past the hook
+  // timeout when the full suite is running
+  const [locations, profile, secondProfile, thirdProfile] = await Promise.all([
+    simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data),
+    simpleOmneoRequest('POST', '/profiles', {
+      first_name: 'SDK',
+      last_name: 'Appointment Test',
+      email: `${getRandomString('sdk_unit_test_link_appointment')}@omneodemo.com`
+    }).then(({ data }) => data),
+    simpleOmneoRequest('POST', '/profiles', {
+      first_name: 'SDK',
+      last_name: 'Linked Attendee',
+      email: `${getRandomString('sdk_unit_test_link_appointment_attendee')}@omneodemo.com`
+    }).then(({ data }) => data),
+    simpleOmneoRequest('POST', '/profiles', {
+      first_name: 'SDK',
+      last_name: 'Second Attendee',
+      email: `${getRandomString('sdk_unit_test_link_appointment_attendee_two')}@omneodemo.com`
+    }).then(({ data }) => data)
+  ])
   CREATED_PROFILE_IDS.push(profile.id)
-
-  const secondProfile = await simpleOmneoRequest('POST', '/profiles', {
-    first_name: 'SDK',
-    last_name: 'Linked Attendee',
-    email: `${getRandomString('sdk_unit_test_link_appointment_attendee')}@omneodemo.com`
-  }).then(({ data }) => data)
   linkedProfileID = secondProfile.id
   CREATED_PROFILE_IDS.push(secondProfile.id)
-
-  const thirdProfile = await simpleOmneoRequest('POST', '/profiles', {
-    first_name: 'SDK',
-    last_name: 'Second Attendee',
-    email: `${getRandomString('sdk_unit_test_link_appointment_attendee_two')}@omneodemo.com`
-  }).then(({ data }) => data)
   secondLinkedProfileID = thirdProfile.id
   CREATED_PROFILE_IDS.push(thirdProfile.id)
 

--- a/src/tests/integration/omneo/appointments/list-appointments.test.ts
+++ b/src/tests/integration/omneo/appointments/list-appointments.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { AppointmentResponse } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let profileID: string
+let seededAppointmentID: number
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Appointment Test',
+    email: `${getRandomString('sdk_unit_test_list_appointments')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_list_appointments_handle'),
+    name: getRandomString('sdk_unit_test_list_appointments_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locations[0].id]
+  }).then(({ data }) => data)
+  definitionID = definition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  const appointment = await simpleOmneoRequest('POST', '/appointments', {
+    appointment_definition_id: definitionID,
+    profile_id: profileID,
+    location_id: locations[0].id,
+    scheduled_start_at: `${futureDate(3)} 10:00:00`,
+    scheduled_end_at: `${futureDate(3)} 10:30:00`,
+    timezone: 'Australia/Melbourne'
+  }).then(({ data }) => data)
+  seededAppointmentID = appointment.id
+  CREATED_APPOINTMENT_IDS.push(appointment.id)
+})
+
+describe('List Appointments', () => {
+  test('SDK List Appointments filtered by profile', async () => {
+    const response: AppointmentResponse = await omneoClient.appointments.list({
+      'filter[profile_id]': profileID
+    }).catch((err) => {
+      console.error('SDK List Appointments failed:', err)
+      throw new Error('SDK List Appointments failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.length).toBe(1)
+    expect(response.data[0].id).toBe(seededAppointmentID)
+  })
+
+  test('SDK List Appointments filtered by definition and status', async () => {
+    const response: AppointmentResponse = await omneoClient.appointments.list({
+      'filter[appointment_definition_id]': definitionID,
+      'filter[status]': 'confirmed'
+    }).catch((err) => {
+      console.error('SDK List Appointments by definition failed:', err)
+      throw new Error('SDK List Appointments by definition failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.length).toBe(1)
+    expect(response.data[0].appointment_definition_id).toBe(definitionID)
+    expect(response.data[0].status).toBe('confirmed')
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/appointments/update-appointment.test.ts
+++ b/src/tests/integration/omneo/appointments/update-appointment.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { Appointment } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let appointmentID: number
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Appointment Test',
+    email: `${getRandomString('sdk_unit_test_update_appointment')}@omneodemo.com`
+  }).then(({ data }) => data)
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_update_appointment_handle'),
+    name: getRandomString('sdk_unit_test_update_appointment_name'),
+    duration_minutes: 30,
+    booking_type: 'approval_required',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locations[0].id]
+  }).then(({ data }) => data)
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+
+  const appointment = await simpleOmneoRequest('POST', '/appointments', {
+    appointment_definition_id: definition.id,
+    profile_id: profile.id,
+    location_id: locations[0].id,
+    scheduled_start_at: `${futureDate(3)} 10:00:00`,
+    scheduled_end_at: `${futureDate(3)} 10:30:00`,
+    timezone: 'Australia/Melbourne'
+  }).then(({ data }) => data)
+  appointmentID = appointment.id
+  CREATED_APPOINTMENT_IDS.push(appointment.id)
+})
+
+describe('Update Appointment', () => {
+  test('SDK Update Appointment status to confirmed stamps confirmed_at', async () => {
+    const appointment: Appointment = await omneoClient.appointments.update(appointmentID, {
+      status: 'confirmed'
+    }).catch((err) => {
+      console.error('SDK Update Appointment (confirm) failed:', err)
+      throw new Error('SDK Update Appointment (confirm) failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(appointment.id).toBe(appointmentID)
+    expect(appointment.status).toBe('confirmed')
+    expect(appointment.confirmed_at).not.toBeNull()
+  })
+
+  test('SDK Update Appointment reschedule', async () => {
+    const appointment: Appointment = await omneoClient.appointments.update(appointmentID, {
+      scheduled_start_at: `${futureDate(5)} 14:00:00`,
+      scheduled_end_at: `${futureDate(5)} 14:30:00`,
+      timezone: 'Australia/Melbourne'
+    }).catch((err) => {
+      console.error('SDK Update Appointment (reschedule) failed:', err)
+      throw new Error('SDK Update Appointment (reschedule) failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(appointment.id).toBe(appointmentID)
+    expect(new Date(appointment.scheduled_start_at).getTime()).not.toBeNaN()
+  })
+
+  test('SDK Update Appointment status to cancelled stamps cancelled_at', async () => {
+    const appointment: Appointment = await omneoClient.appointments.update(appointmentID, {
+      status: 'cancelled'
+    }).catch((err) => {
+      console.error('SDK Update Appointment (cancel) failed:', err)
+      throw new Error('SDK Update Appointment (cancel) failed')
+    })
+
+    expect(appointment).toBeDefined()
+    expect(appointment.status).toBe('cancelled')
+    expect(appointment.cancelled_at).not.toBeNull()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/auth/delete-api-token.test.ts
+++ b/src/tests/integration/omneo/auth/delete-api-token.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, afterAll, expect } from 'vitest'
-import { simpleOmneoRequest } from '@lib'
+import { getRandomString, simpleOmneoRequest } from '@lib'
 import { Omneo } from '@omneo'
-import { APIToken } from '@types'
+import { APITokenResponse } from '@types'
 
 const FAILED_DELETE_API_TOKENS : string[] = []
 
@@ -10,7 +10,9 @@ const omneo = new Omneo({
   token: process.env.OMNEO_TOKEN as string
 })
 
-const tokenName = 'SDK Tokens Delete Test API Token'
+// /auth/access-tokens is paginated, so absence is checked against a
+// name-filtered lookup rather than the first page of every token on the tenant.
+const tokenName = getRandomString('sdk_unit_test_tokens_delete')
 
 describe('API Tokens delete', () => {
   test('SDK can delete an API Token', async () => {
@@ -28,9 +30,9 @@ describe('API Tokens delete', () => {
     })
 
     // Cannot fetch API token by ID
-    const tokens: APIToken[] = await simpleOmneoRequest('GET', '/auth/access-tokens?type=current')
+    const tokens: APITokenResponse = await simpleOmneoRequest('GET', `/auth/access-tokens?type=current&filter[name]=${tokenName}`)
 
-    const matchedToken = tokens.find((tkn) => tkn.id === tokenID)
+    const matchedToken = tokens.data.find((tkn) => tkn.id === tokenID)
 
     if (matchedToken) FAILED_DELETE_API_TOKENS.push(tokenID)
 

--- a/src/tests/integration/omneo/auth/get-api-tokens.test.ts
+++ b/src/tests/integration/omneo/auth/get-api-tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, afterAll, expect } from 'vitest'
-import { simpleOmneoRequest } from '@lib'
+import { getRandomString, simpleOmneoRequest } from '@lib'
 import { Omneo } from '@omneo'
 
 const CREATED_API_TOKENS : string[] = []
@@ -9,7 +9,10 @@ const omneo = new Omneo({
   token: process.env.OMNEO_TOKEN as string
 })
 
-const tokenName = 'SDK Tokens Get Test API Token'
+// The tenant accumulates hundreds of tokens and /auth/access-tokens is
+// paginated, so the test token is looked up by a unique name rather than
+// scanned for in the first page of results.
+const tokenName = getRandomString('sdk_unit_test_tokens_get')
 
 describe('API Tokens get', async () => {
   const { token: { id: testTokenID } } = await simpleOmneoRequest('POST', '/auth/api-tokens', {
@@ -20,20 +23,23 @@ describe('API Tokens get', async () => {
   CREATED_API_TOKENS.push(testTokenID)
 
   test('SDK can get current API tokens', async () => {
-    const currentTokens = await omneo.auth.getAPITokens({ type: 'current' })
-    const matchedToken = currentTokens.find((tkn) => tkn.id === testTokenID)
+    const currentTokens = await omneo.auth.getAPITokens({ type: 'current', 'filter[name]': tokenName })
+    const matchedToken = currentTokens.data.find((tkn) => tkn.id === testTokenID)
 
     expect(matchedToken).toBeDefined()
     expect(matchedToken?.id).toEqual(testTokenID)
 
-    const expiredTokens = currentTokens.filter((tkn) => new Date(tkn.expires_at).getTime() < Date.now())
+    const expiredTokens = currentTokens.data.filter((tkn) => new Date(tkn.expires_at).getTime() < Date.now())
     expect(expiredTokens.length).toEqual(0)
   })
 
-  test('SDK can get current API tokens', async () => {
+  // /auth/access-tokens ignores the `type` parameter — `current`, `expired`
+  // and even a garbage value all return the identical unfiltered set
+  // (verified 2026-08-04). Unskip once the platform honours the filter again.
+  test.skip('SDK can get expired API tokens', async () => {
     const expiredTokens = await omneo.auth.getAPITokens({ type: 'expired' })
 
-    const currentTokens = expiredTokens.filter((tkn) => new Date(tkn.expires_at).getTime() > Date.now())
+    const currentTokens = expiredTokens.data.filter((tkn) => new Date(tkn.expires_at).getTime() > Date.now())
     expect(currentTokens.length).toEqual(0)
   })
 })

--- a/src/tests/integration/omneo/profiles/appointments/list-visible-definitions.test.ts
+++ b/src/tests/integration/omneo/profiles/appointments/list-visible-definitions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let profileID: string
+let visibleDefinitionID: number
+let hiddenDefinitionID: number
+
+beforeAll(async () => {
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Visibility Test',
+    email: `${getRandomString('sdk_unit_test_visible_definitions')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  // Always-true visibility condition, so every profile passes the check
+  const visibleDefinition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_visible_definition_handle'),
+    name: getRandomString('sdk_unit_test_visible_definition_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    is_published: true,
+    visibility_condition: { '==': [1, 1] }
+  }).then(({ data }) => data)
+  visibleDefinitionID = visibleDefinition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(visibleDefinition.id)
+
+  // A null visibility_condition never passes the visibility check
+  const hiddenDefinition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_hidden_definition_handle'),
+    name: getRandomString('sdk_unit_test_hidden_definition_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    is_published: true
+  }).then(({ data }) => data)
+  hiddenDefinitionID = hiddenDefinition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(hiddenDefinition.id)
+})
+
+describe('List Visible Appointment Definitions', () => {
+  test('SDK List Visible Appointment Definitions for a profile', async () => {
+    const response = await omneoClient.profiles.appointments.listVisibleDefinitions(profileID).catch((err) => {
+      console.error('SDK List Visible Appointment Definitions failed:', err)
+      throw new Error('SDK List Visible Appointment Definitions failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((definition) => definition.id === visibleDefinitionID)).toBeDefined()
+    expect(response.data.find((definition) => definition.id === hiddenDefinitionID)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/profiles/appointments/manage-profile-appointments.test.ts
+++ b/src/tests/integration/omneo/profiles/appointments/manage-profile-appointments.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { Appointment } from '@types'
+import { simpleOmneoRequest, getRandomString, seedAppointmentDefinition, DEFINITION_ALL_WEEK_HOURS } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_APPOINTMENT_IDS: number[] = []
+const CREATED_APPOINTMENT_DEFINITION_IDS: number[] = []
+const CREATED_PROFILE_IDS: string[] = []
+let definitionID: number
+let locationID: number
+let profileID: string
+let otherProfileID: string
+
+const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+beforeAll(async () => {
+  const locations = await simpleOmneoRequest('GET', '/locations?page[size]=1').then(({ data }) => data)
+  locationID = locations[0].id
+
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Profile Appointment Test',
+    email: `${getRandomString('sdk_unit_test_profile_appointments')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+
+  const otherProfile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Other Profile',
+    email: `${getRandomString('sdk_unit_test_profile_appointments_other')}@omneodemo.com`
+  }).then(({ data }) => data)
+  otherProfileID = otherProfile.id
+  CREATED_PROFILE_IDS.push(otherProfile.id)
+
+  const definition = await seedAppointmentDefinition({
+    handle: getRandomString('sdk_unit_test_profile_appointments_handle'),
+    name: getRandomString('sdk_unit_test_profile_appointments_name'),
+    duration_minutes: 30,
+    booking_type: 'instant',
+    normal_hours: DEFINITION_ALL_WEEK_HOURS,
+    min_lead_minutes: 0,
+    is_published: true,
+    location_ids: [locationID]
+  }).then(({ data }) => data)
+  definitionID = definition.id
+  CREATED_APPOINTMENT_DEFINITION_IDS.push(definition.id)
+})
+
+describe('Manage Profile Appointments', () => {
+  let appointment: Appointment
+
+  test('SDK Create Profile Appointment infers profile from the URL', async () => {
+    appointment = await omneoClient.profiles.appointments.create(profileID, {
+      appointment_definition_id: definitionID,
+      location_id: locationID,
+      scheduled_start_at: `${futureDate(3)} 10:00:00`,
+      scheduled_end_at: `${futureDate(3)} 10:30:00`,
+      timezone: 'Australia/Melbourne'
+    }).catch((err) => {
+      console.error('SDK Create Profile Appointment failed:', err)
+      throw new Error('SDK Create Profile Appointment failed')
+    })
+    CREATED_APPOINTMENT_IDS.push(appointment.id)
+
+    expect(appointment).toBeDefined()
+    expect(appointment.profile_id).toBe(profileID)
+    expect(appointment.appointment_definition_id).toBe(definitionID)
+  })
+
+  test('SDK List Profile Appointments', async () => {
+    const response = await omneoClient.profiles.appointments.list(profileID).catch((err) => {
+      console.error('SDK List Profile Appointments failed:', err)
+      throw new Error('SDK List Profile Appointments failed')
+    })
+
+    expect(response).toBeDefined()
+    expect(Array.isArray(response.data)).toBe(true)
+    expect(response.data.find((item) => item.id === appointment.id)).toBeDefined()
+  })
+
+  test('SDK Get Profile Appointment', async () => {
+    const found = await omneoClient.profiles.appointments.get(profileID, appointment.id).catch((err) => {
+      console.error('SDK Get Profile Appointment failed:', err)
+      throw new Error('SDK Get Profile Appointment failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(appointment.id)
+    expect(found.profile_id).toBe(profileID)
+  })
+
+  test('SDK Get Profile Appointment returns 404 for another profile', async () => {
+    const error = await omneoClient.profiles.appointments.get(otherProfileID, appointment.id).then(() => null).catch((err) => err)
+    expect(error).not.toBeNull()
+  })
+
+  test('SDK Update Profile Appointment', async () => {
+    const updated = await omneoClient.profiles.appointments.update(profileID, appointment.id, {
+      notes: 'SDK unit test updated note'
+    }).catch((err) => {
+      console.error('SDK Update Profile Appointment failed:', err)
+      throw new Error('SDK Update Profile Appointment failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.id).toBe(appointment.id)
+    expect(updated.notes).toBe('SDK unit test updated note')
+  })
+
+  test('SDK Delete Profile Appointment', async () => {
+    await omneoClient.profiles.appointments.delete(profileID, appointment.id).catch((err) => {
+      console.error('SDK Delete Profile Appointment failed:', err)
+      throw new Error('SDK Delete Profile Appointment failed')
+    })
+
+    const response = await simpleOmneoRequest('GET', `/appointments/${appointment.id}`)
+    expect(response.status).toBe(404)
+    CREATED_APPOINTMENT_IDS.length = 0
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_APPOINTMENT_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointments/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_APPOINTMENT_DEFINITION_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/appointment-definitions/${id}`)
+    if (response.status === 204) {
+      console.log(`SDK Appointment Definition ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Appointment Definition ID ${id}`, response)
+    }
+  }
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/profiles/normal-hours/manage-profile-normal-hours.test.ts
+++ b/src/tests/integration/omneo/profiles/normal-hours/manage-profile-normal-hours.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { ProfileNormalHour } from '@types'
+import { simpleOmneoRequest, getRandomString } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_PROFILE_IDS: string[] = []
+let profileID: string
+
+beforeAll(async () => {
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Normal Hours Test',
+    email: `${getRandomString('sdk_unit_test_profile_normal_hours')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+})
+
+describe('Manage Profile Normal Hours', () => {
+  let normalHour: ProfileNormalHour
+
+  test('SDK Create Profile Normal Hour', async () => {
+    const payload = {
+      day_of_week: 'MON' as const,
+      available_from: '09:00',
+      available_until: '17:00'
+    }
+
+    normalHour = await omneoClient.profiles.normalHours.create(profileID, payload).catch((err) => {
+      console.error('SDK Create Profile Normal Hour failed:', err)
+      throw new Error('SDK Create Profile Normal Hour failed')
+    })
+
+    expect(normalHour).toBeDefined()
+    expect(normalHour.day_of_week).toBe(payload.day_of_week)
+    expect(normalHour.profile_id).toBe(profileID)
+  })
+
+  test('SDK List Profile Normal Hours', async () => {
+    const normalHours = await omneoClient.profiles.normalHours.list(profileID).catch((err) => {
+      console.error('SDK List Profile Normal Hours failed:', err)
+      throw new Error('SDK List Profile Normal Hours failed')
+    })
+
+    expect(Array.isArray(normalHours)).toBe(true)
+    expect(normalHours.find((hour) => hour.id === normalHour.id)).toBeDefined()
+  })
+
+  test('SDK Get Profile Normal Hour', async () => {
+    const found = await omneoClient.profiles.normalHours.get(profileID, normalHour.id).catch((err) => {
+      console.error('SDK Get Profile Normal Hour failed:', err)
+      throw new Error('SDK Get Profile Normal Hour failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(normalHour.id)
+    expect(found.day_of_week).toBe(normalHour.day_of_week)
+  })
+
+  test('SDK Update Profile Normal Hour', async () => {
+    const updated = await omneoClient.profiles.normalHours.update(profileID, normalHour.id, {
+      available_until: '18:00'
+    }).catch((err) => {
+      console.error('SDK Update Profile Normal Hour failed:', err)
+      throw new Error('SDK Update Profile Normal Hour failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.id).toBe(normalHour.id)
+    expect(updated.available_until).toContain('18:00')
+  })
+
+  test('SDK Delete Profile Normal Hour', async () => {
+    await omneoClient.profiles.normalHours.delete(profileID, normalHour.id).catch((err) => {
+      console.error('SDK Delete Profile Normal Hour failed:', err)
+      throw new Error('SDK Delete Profile Normal Hour failed')
+    })
+
+    const normalHours = await omneoClient.profiles.normalHours.list(profileID)
+    expect(normalHours.find((hour) => hour.id === normalHour.id)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/profiles/special-hours/manage-profile-special-hours.test.ts
+++ b/src/tests/integration/omneo/profiles/special-hours/manage-profile-special-hours.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, beforeAll, afterAll } from 'vitest'
+import { Omneo } from '@omneo'
+import { ProfileSpecialHour } from '@types'
+import { simpleOmneoRequest, getRandomString } from '@lib'
+
+const omneoClient = new Omneo({
+  tenant: process.env.OMNEO_TENANT as string,
+  token: process.env.OMNEO_TOKEN as string
+})
+const CREATED_PROFILE_IDS: string[] = []
+let profileID: string
+
+beforeAll(async () => {
+  const profile = await simpleOmneoRequest('POST', '/profiles', {
+    first_name: 'SDK',
+    last_name: 'Special Hours Test',
+    email: `${getRandomString('sdk_unit_test_profile_special_hours')}@omneodemo.com`
+  }).then(({ data }) => data)
+  profileID = profile.id
+  CREATED_PROFILE_IDS.push(profile.id)
+})
+
+describe('Manage Profile Special Hours', () => {
+  let specialHour: ProfileSpecialHour
+
+  test('SDK Create Profile Special Hour', async () => {
+    const payload = {
+      name: getRandomString('sdk_unit_test_profile_special_hour_name'),
+      start_at: '2026-12-24',
+      end_at: '2026-12-26',
+      is_repeating: false
+    }
+
+    specialHour = await omneoClient.profiles.specialHours.create(profileID, payload).catch((err) => {
+      console.error('SDK Create Profile Special Hour failed:', err)
+      throw new Error('SDK Create Profile Special Hour failed')
+    })
+
+    expect(specialHour).toBeDefined()
+    expect(specialHour.name).toBe(payload.name)
+    expect(specialHour.is_repeating).toBe(payload.is_repeating)
+    expect(specialHour.profile_id).toBe(profileID)
+  })
+
+  test('SDK List Profile Special Hours', async () => {
+    const specialHours = await omneoClient.profiles.specialHours.list(profileID).catch((err) => {
+      console.error('SDK List Profile Special Hours failed:', err)
+      throw new Error('SDK List Profile Special Hours failed')
+    })
+
+    expect(Array.isArray(specialHours)).toBe(true)
+    expect(specialHours.find((hour) => hour.id === specialHour.id)).toBeDefined()
+  })
+
+  test('SDK Get Profile Special Hour', async () => {
+    const found = await omneoClient.profiles.specialHours.get(profileID, specialHour.id).catch((err) => {
+      console.error('SDK Get Profile Special Hour failed:', err)
+      throw new Error('SDK Get Profile Special Hour failed')
+    })
+
+    expect(found).toBeDefined()
+    expect(found.id).toBe(specialHour.id)
+    expect(found.name).toBe(specialHour.name)
+  })
+
+  test('SDK Update Profile Special Hour', async () => {
+    const updated = await omneoClient.profiles.specialHours.update(profileID, specialHour.id, {
+      end_at: '2026-12-27'
+    }).catch((err) => {
+      console.error('SDK Update Profile Special Hour failed:', err)
+      throw new Error('SDK Update Profile Special Hour failed')
+    })
+
+    expect(updated).toBeDefined()
+    expect(updated.id).toBe(specialHour.id)
+    expect(updated.end_at).toContain('2026-12-27')
+  })
+
+  test('SDK Delete Profile Special Hour', async () => {
+    await omneoClient.profiles.specialHours.delete(profileID, specialHour.id).catch((err) => {
+      console.error('SDK Delete Profile Special Hour failed:', err)
+      throw new Error('SDK Delete Profile Special Hour failed')
+    })
+
+    const specialHours = await omneoClient.profiles.specialHours.list(profileID)
+    expect(specialHours.find((hour) => hour.id === specialHour.id)).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  for (const id of CREATED_PROFILE_IDS) {
+    const response = await simpleOmneoRequest('DELETE', `/profiles/${id}`)
+    if (response.status === 204 || response.data) {
+      console.log(`SDK Profile ID ${id} deleted`)
+    } else {
+      console.log(`Failed to delete Profile ID ${id}`, response)
+    }
+  }
+})

--- a/src/tests/integration/omneo/profiles/tiers/assign-profile-tier.test.ts
+++ b/src/tests/integration/omneo/profiles/tiers/assign-profile-tier.test.ts
@@ -15,11 +15,13 @@ describe('Profile Tiers - Assign', () => {
   test('SDK can assign a tier to a profile', async () => {
     let tierDefinition: any
 
-    // First, try to get existing tier definitions
+    // First, try to get existing tier definitions. The assign endpoint only
+    // resolves assignable definitions, so a non-assignable one (e.g. the floor
+    // tier) 404s with "No query results for model [App\Models\TierDefinition]"
     const existingDefinitions = await simpleOmneoRequest('GET', '/tiers/definitions')
-    if (existingDefinitions.data && existingDefinitions.data.length > 0) {
-      // Use the first existing tier definition
-      tierDefinition = { data: existingDefinitions.data[0] }
+    const assignableDefinition = existingDefinitions.data?.find((definition: any) => definition.is_assignable)
+    if (assignableDefinition) {
+      tierDefinition = { data: assignableDefinition }
     } else {
       // Create a new tier definition if none exist
       const tierDefinitionPayload = {

--- a/src/tests/lib/appointment-helpers.ts
+++ b/src/tests/lib/appointment-helpers.ts
@@ -1,0 +1,42 @@
+import simpleOmneoRequest from './simple-omneo-request'
+import { getRandomString } from './string/util'
+
+const WEEK_DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+
+// The live API requires normal_hours when creating an appointment definition
+export const DEFINITION_ALL_WEEK_HOURS = WEEK_DAYS.map((day) => {
+  return { day_of_week: day, available_from: '09:00', available_until: '17:00' }
+})
+
+// Availability is the intersection of definition hours and location hours, so
+// appointment tests seed their own location with full-week opening hours
+// rather than relying on the tenant's (sparsely configured) locations.
+export const seedAppointmentTestLocation = async () => {
+  const response = await simpleOmneoRequest('POST', '/locations', {
+    name: getRandomString('sdk_unit_test_appointment_location'),
+    handle: getRandomString('sdk_unit_test_appointment_location_handle'),
+    timezone: 'Australia/Melbourne',
+    phone: '+61390000000',
+    normal_hours: WEEK_DAYS.map((day) => {
+      return { day_of_week: day, open_at: '08:00', close_at: '18:00' }
+    })
+  })
+  return response.data
+}
+
+export const futureDate = (daysAhead: number): string => {
+  const date = new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000)
+  return date.toISOString().split('T')[0]
+}
+
+// Concurrent appointment-definition creates intermittently return 500 from
+// the live API, so seeding retries before failing the suite
+export const seedAppointmentDefinition = async (payload: { [key: string]: any }) => {
+  let response
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    response = await simpleOmneoRequest('POST', '/appointment-definitions', payload)
+    if (response?.data?.id) return response
+    console.log(`Appointment definition seed attempt ${attempt} failed`, response)
+  }
+  throw Error('Failed to seed appointment definition')
+}

--- a/src/tests/lib/appointment-helpers.ts
+++ b/src/tests/lib/appointment-helpers.ts
@@ -30,13 +30,17 @@ export const futureDate = (daysAhead: number): string => {
 }
 
 // Concurrent appointment-definition creates intermittently return 500 from
-// the live API, so seeding retries before failing the suite
+// the live API, so seeding retries with exponential back-off before failing
 export const seedAppointmentDefinition = async (payload: { [key: string]: any }) => {
   let response
-  for (let attempt = 1; attempt <= 3; attempt++) {
+  for (let attempt = 1; attempt <= 5; attempt++) {
     response = await simpleOmneoRequest('POST', '/appointment-definitions', payload)
     if (response?.data?.id) return response
     console.log(`Appointment definition seed attempt ${attempt} failed`, response)
+    if (attempt < 5) {
+      const delay = Math.min(1000 * 2 ** (attempt - 1) + Math.random() * 500, 10000)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
   }
   throw Error('Failed to seed appointment definition')
 }

--- a/src/tests/lib/index.ts
+++ b/src/tests/lib/index.ts
@@ -2,5 +2,6 @@ import { getRandomString, getIsoNumeric, convertToUTC, formatUtcToTimezone } fro
 import randomString from './string/random'
 import simpleOmneoRequest from './simple-omneo-request'
 import simpleIDRequest from './simple-id-request'
+import { DEFINITION_ALL_WEEK_HOURS, seedAppointmentTestLocation, seedAppointmentDefinition, futureDate } from './appointment-helpers'
 
-export { randomString, simpleOmneoRequest, simpleIDRequest, getRandomString, getIsoNumeric, convertToUTC, formatUtcToTimezone }
+export { randomString, simpleOmneoRequest, simpleIDRequest, getRandomString, getIsoNumeric, convertToUTC, formatUtcToTimezone, DEFINITION_ALL_WEEK_HOURS, seedAppointmentTestLocation, seedAppointmentDefinition, futureDate }

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -1,0 +1,560 @@
+import { PaginationResponse } from './pagination'
+
+export type AppointmentStatus = 'requested' | 'confirmed' | 'cancelled' | 'arrived' | 'completed' | 'no_show' | 'rejected'
+export type AppointmentBookingType = 'instant' | 'approval_required' | 'walk_in_only'
+export type AppointmentQueueStatus = 'waiting' | 'called' | 'served' | 'cancelled'
+export type AppointmentWaitlistStatus = 'active' | 'fulfilled' | 'cancelled'
+export type AppointmentDayOfWeek = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN'
+export type AppointmentLinkType = 'profile' | 'list'
+
+export type AppointmentProfileSummary = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  email: string | null
+}
+
+export type AppointmentLocationSummary = {
+  id: number
+  name: string
+  handle: string
+  timezone: string | null
+}
+
+export type AppointmentDefinitionNormalHour = {
+  id: number
+  appointment_definition_id: number
+  day_of_week: AppointmentDayOfWeek
+  available_from: string | null
+  available_until: string | null
+  is_closed: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentDefinitionNormalHourInput = {
+  day_of_week: AppointmentDayOfWeek
+  available_from?: string | null
+  available_until?: string | null
+}
+
+export type UpdateAppointmentDefinitionNormalHourInput = Partial<CreateAppointmentDefinitionNormalHourInput>
+
+export type AppointmentDefinitionSpecialHour = {
+  id: number
+  appointment_definition_id: number
+  name: string
+  is_repeating: boolean
+  available_from: string | null
+  available_until: string | null
+  start_at: string
+  end_at: string
+  is_closed: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentDefinitionSpecialHourInput = {
+  name: string
+  start_at: string
+  end_at: string
+  is_repeating?: boolean
+  available_from?: string | null
+  available_until?: string | null
+}
+
+export type UpdateAppointmentDefinitionSpecialHourInput = Partial<CreateAppointmentDefinitionSpecialHourInput>
+
+export type AppointmentDefinitionLocation = {
+  id: number
+  appointment_definition_id: number
+  location_id: number
+  is_active: boolean
+  location: {
+    id: number
+    name: string
+    handle: string
+    [key: string]: any
+  } | null
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentDefinitionLocationInput = {
+  location_id: number
+  is_active?: boolean
+}
+
+export type UpdateAppointmentDefinitionLocationInput = {
+  is_active?: boolean
+}
+
+export type AppointmentDefinitionStaff = {
+  id: number
+  appointment_definition_id: number
+  staff_id: string
+  is_active: boolean
+  staff: {
+    id: string
+    first_name: string | null
+    last_name: string | null
+    email: string | null
+    mobile_phone: string | null
+    [key: string]: any
+  } | null
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentDefinitionStaffInput = {
+  staff_id: string
+  is_active?: boolean
+}
+
+export type UpdateAppointmentDefinitionStaffInput = {
+  is_active?: boolean
+}
+
+export type AppointmentBookingQuestionnaireQuestionInput = {
+  mapping_key: string
+  question_id?: number
+  question_handle?: string
+  question_version_id?: number | null
+  sort_order?: number
+  is_required?: boolean
+  visibility_condition?: { [key: string]: any } | null
+  is_active?: boolean
+}
+
+export type AppointmentBookingQuestionnairePageInput = {
+  title?: string | null
+  description?: string | null
+  image_url?: string | null
+  section_header?: string | null
+  sort_order?: number
+  questions?: AppointmentBookingQuestionnaireQuestionInput[]
+}
+
+export type AppointmentBookingQuestionnaireInput = {
+  name?: string
+  handle?: string | null
+  description?: string | null
+  is_active?: boolean
+  meta?: { [key: string]: any } | null
+  questions?: AppointmentBookingQuestionnaireQuestionInput[]
+  pages?: AppointmentBookingQuestionnairePageInput[]
+}
+
+export type AppointmentDefinition = {
+  id: number
+  handle: string
+  name: string
+  description: string | null
+  short_description: string | null
+  long_description: string | null
+  icon: string | null
+  image_url: string | null
+  terms_conditions: string | null
+  internal_notes: string | null
+  visibility_condition: { [key: string]: any } | null
+  is_published: boolean
+  is_archived: boolean
+  duration_minutes: number
+  buffer_before_minutes: number
+  buffer_after_minutes: number
+  min_lead_minutes: number
+  max_advance_days: number | null
+  slot_interval_minutes: number | null
+  booking_type: AppointmentBookingType
+  allow_customer_booking: boolean
+  allow_walk_in: boolean
+  requires_staff: boolean
+  customer_must_select_staff: boolean
+  use_staff_from_location: boolean
+  max_concurrent_bookings: number | null
+  allow_waitlist: boolean
+  allow_queue: boolean
+  queue_code?: string | null
+  meta: { [key: string]: any } | null
+  created_target_id: number | null
+  confirmed_target_id: number | null
+  cancelled_target_id: number | null
+  rejected_target_id: number | null
+  reminder_target_id: number | null
+  completed_target_id: number | null
+  notify_created_offset_days: number | null
+  notify_created_offset_hours: number | null
+  notify_confirmed_offset_days: number | null
+  notify_confirmed_offset_hours: number | null
+  notify_cancelled_offset_days: number | null
+  notify_cancelled_offset_hours: number | null
+  notify_rejected_offset_days: number | null
+  notify_rejected_offset_hours: number | null
+  notify_reminder_offset_days: number | null
+  notify_reminder_offset_hours: number | null
+  notify_completed_offset_days: number | null
+  notify_completed_offset_hours: number | null
+  has_booking_questionnaire: boolean
+  normal_hours?: AppointmentDefinitionNormalHour[]
+  special_hours?: AppointmentDefinitionSpecialHour[]
+  locations?: AppointmentDefinitionLocation[]
+  staff?: AppointmentDefinitionStaff[]
+  booking_questionnaire?: { [key: string]: any } | null
+  created_at: string
+  updated_at: string
+}
+
+type AppointmentDefinitionEditable = Omit<AppointmentDefinition, 'id' | 'queue_code' | 'has_booking_questionnaire' | 'normal_hours' | 'special_hours' | 'locations' | 'staff' | 'booking_questionnaire' | 'created_at' | 'updated_at'>
+type AppointmentDefinitionCreateRequiredField = 'handle' | 'name' | 'duration_minutes' | 'booking_type'
+
+export type CreateAppointmentDefinitionInput =
+  Required<Pick<AppointmentDefinitionEditable, AppointmentDefinitionCreateRequiredField>> &
+  Partial<Omit<AppointmentDefinitionEditable, AppointmentDefinitionCreateRequiredField>> & {
+    location_ids?: number[]
+    staff_ids?: string[]
+    normal_hours?: CreateAppointmentDefinitionNormalHourInput[]
+    special_hours?: CreateAppointmentDefinitionSpecialHourInput[]
+    booking_questionnaire?: AppointmentBookingQuestionnaireInput
+  }
+
+export type UpdateAppointmentDefinitionInput = Partial<Omit<CreateAppointmentDefinitionInput, 'handle'>>
+
+export type AppointmentDefinitionResponse = PaginationResponse & {
+  data: AppointmentDefinition[]
+}
+
+export type AppointmentDefinitionQuestions = {
+  questionnaire: { [key: string]: any } | null
+  questions: any[]
+}
+
+export type AppointmentAvailableSlotsInput = {
+  location_id: number
+  date: string
+  staff_id?: string | null
+}
+
+export type AppointmentAvailabilityMeta = {
+  slot_interval_minutes: number | null
+  duration_minutes: number
+  buffer_before_minutes: number
+  buffer_after_minutes: number
+  min_lead_minutes: number
+  max_advance_days: number | null
+  max_concurrent_bookings: number | null
+}
+
+export type AppointmentSlot = {
+  time: string
+  label: string
+  start_at: string
+  end_at: string
+  duration_minutes: number
+  capacity_remaining: number | null
+}
+
+export type AppointmentAvailableSlots = {
+  date: string
+  timezone: string | null
+  appointment_definition_id: number
+  location_id: number
+  requires_staff: boolean
+  customer_must_select_staff: boolean
+  assigned_staff_required: boolean
+  staff: AppointmentProfileSummary | null
+  slots: AppointmentSlot[]
+}
+
+export type AppointmentAvailableSlotsResponse = {
+  data: AppointmentAvailableSlots
+  meta: AppointmentAvailabilityMeta
+}
+
+export type AppointmentAvailableSlotsRangeInput = {
+  location_id: number
+  start_date: string
+  end_date: string
+  staff_id?: string | null
+  sort?: 'asc' | 'desc'
+}
+
+export type AppointmentAvailableSlotsRangeResponse = {
+  data: AppointmentSlot[]
+  meta: AppointmentAvailabilityMeta & {
+    appointment_definition_id: number
+    location_id: number
+    timezone: string | null
+    start_date: string
+    end_date: string
+    requires_staff: boolean
+    customer_must_select_staff: boolean
+    assigned_staff_required: boolean
+    staff: AppointmentProfileSummary | null
+    total: number
+  }
+}
+
+export type AppointmentAvailableStaffInput = {
+  location_id: number
+  date: string
+  available_only?: boolean
+}
+
+export type AppointmentAvailableStaffMember = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  email: string | null
+  has_available_slots: boolean
+  is_default_location: boolean
+  appointment_definition_staff_sort_order?: number | null
+  location_profile_sort_order?: number | null
+}
+
+export type AppointmentAvailableStaffResponse = {
+  data: AppointmentAvailableStaffMember[]
+  meta: {
+    appointment_definition_id: number
+    location_id: number
+    date: string
+    requires_staff: boolean
+    customer_must_select_staff: boolean
+    selection_required_by_customer: boolean
+    assigned_staff_required: boolean
+  }
+}
+
+export type AppointmentTransactionResolver = {
+  id?: number
+  external_id?: string
+  receipt_ref?: string
+}
+
+export type AppointmentOrderResolver = {
+  id?: number
+  external_id?: string
+  receipt_ref?: string
+  order_number?: string
+}
+
+export type AppointmentAnswer = {
+  id: number
+  questionnaire_question_id: number
+  question_id: number
+  question_handle: string
+  question_version_id: number
+  mapping_key: string
+  link_type: string | null
+  link_target: string | null
+  question_label: string
+  question_type: string
+  value: string
+  mapping_status: string
+  mapping_error: string | null
+  mapped_at: string | null
+  meta: { [key: string]: any } | null
+  created_at: string
+  updated_at: string
+}
+
+export type AppointmentLink = {
+  id: number
+  type: AppointmentLinkType
+  target_id: string | number
+  profile: AppointmentProfileSummary | null
+  linkable: { [key: string]: any } | null
+}
+
+export type Appointment = {
+  id: number
+  appointment_definition_id: number
+  appointment_definition: AppointmentDefinition | null
+  profile_id: string
+  profile: AppointmentProfileSummary | null
+  location_id: number
+  location: AppointmentLocationSummary | null
+  assigned_staff_id: string | null
+  assigned_staff: AppointmentProfileSummary | null
+  status: AppointmentStatus
+  scheduled_start_at: string
+  scheduled_end_at: string
+  timezone: string
+  approved_at: string | null
+  confirmed_at: string | null
+  cancelled_at: string | null
+  arrived_at: string | null
+  completed_at: string | null
+  no_show_at: string | null
+  rejected_at: string | null
+  approved_by: string | null
+  cancelled_by: string | null
+  rejected_by: string | null
+  transaction_id: number | null
+  order_id: number | null
+  transaction: { [key: string]: any } | null
+  order: { [key: string]: any } | null
+  answers: AppointmentAnswer[]
+  links?: AppointmentLink[] // Only returned by the link endpoint, not by reads
+  notes: string | null
+  meta: { [key: string]: any } | null
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentAnswerInput = {
+  questionnaire_question_id?: number
+  value: string
+}
+
+export type CreateAppointmentInput = {
+  appointment_definition_id: number
+  profile_id: string
+  location_id: number
+  scheduled_start_at: string
+  scheduled_end_at: string
+  timezone: string
+  assigned_staff_id?: string | null
+  status?: AppointmentStatus
+  confirmed_at?: string | null
+  notes?: string | null
+  meta?: { [key: string]: any } | null
+  transaction?: AppointmentTransactionResolver | null
+  order?: AppointmentOrderResolver | null
+  answers?: CreateAppointmentAnswerInput[]
+}
+
+export type CreateProfileAppointmentInput = Omit<CreateAppointmentInput, 'profile_id'>
+
+export type UpdateAppointmentInput = Partial<Omit<CreateAppointmentInput, 'answers'>>
+
+export type AppointmentResponse = PaginationResponse & {
+  data: Appointment[]
+}
+
+export type AppointmentLinkInput = {
+  type: AppointmentLinkType
+  id: string | number
+}
+
+export type AppointmentQueue = {
+  id: number
+  appointment_definition_id: number
+  profile_id: string | null
+  profile: AppointmentProfileSummary | null
+  location_id: number
+  location: AppointmentLocationSummary | null
+  staff_id: string | null
+  staff: AppointmentProfileSummary | null
+  appointment_id: number | null
+  status: AppointmentQueueStatus
+  notes: string | null
+  meta: { [key: string]: any } | null
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentQueueInput = {
+  appointment_definition_id: number
+  location_id: number
+  profile_id?: string | null
+  staff_id?: string | null
+  appointment_id?: number | null
+  status?: AppointmentQueueStatus
+  notes?: string | null
+  meta?: { [key: string]: any } | null
+}
+
+export type UpdateAppointmentQueueInput = {
+  staff_id?: string | null
+  appointment_id?: number | null
+  status?: AppointmentQueueStatus
+  notes?: string | null
+  meta?: { [key: string]: any } | null
+}
+
+export type AppointmentQueueResponse = PaginationResponse & {
+  data: AppointmentQueue[]
+}
+
+export type AppointmentWaitlist = {
+  id: number
+  appointment_definition_id: number
+  profile_id: string
+  profile: AppointmentProfileSummary | null
+  location_id: number
+  location: AppointmentLocationSummary | null
+  appointment_id: number | null
+  status: AppointmentWaitlistStatus
+  desired_start_at: string | null
+  notes: string | null
+  meta: { [key: string]: any } | null
+  created_at: string
+  updated_at: string
+}
+
+export type CreateAppointmentWaitlistInput = {
+  appointment_definition_id: number
+  profile_id: string
+  location_id: number
+  appointment_id?: number | null
+  status?: AppointmentWaitlistStatus
+  desired_start_at?: string | null
+  notes?: string | null
+  meta?: { [key: string]: any } | null
+}
+
+export type UpdateAppointmentWaitlistInput = {
+  appointment_id?: number | null
+  status?: AppointmentWaitlistStatus
+  desired_start_at?: string | null
+  notes?: string | null
+  meta?: { [key: string]: any } | null
+}
+
+export type AppointmentWaitlistResponse = PaginationResponse & {
+  data: AppointmentWaitlist[]
+}
+
+export type ProfileNormalHour = {
+  id: number
+  profile_id: string
+  day_of_week: AppointmentDayOfWeek
+  available_from: string | null
+  available_until: string | null
+  is_closed: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type CreateProfileNormalHourInput = {
+  day_of_week: AppointmentDayOfWeek
+  available_from?: string | null
+  available_until?: string | null
+}
+
+export type UpdateProfileNormalHourInput = Partial<CreateProfileNormalHourInput>
+
+export type ProfileSpecialHour = {
+  id: number
+  profile_id: string
+  name: string
+  is_repeating: boolean
+  available_from: string | null
+  available_until: string | null
+  start_at: string
+  end_at: string
+  is_closed: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type CreateProfileSpecialHourInput = {
+  name: string
+  start_at: string
+  end_at: string
+  is_repeating?: boolean
+  available_from?: string | null
+  available_until?: string | null
+}
+
+export type UpdateProfileSpecialHourInput = Partial<CreateProfileSpecialHourInput>

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,4 @@
+import { PaginationResponse } from './pagination'
 import { User } from './user'
 
 export type APIScopes =
@@ -7,6 +8,22 @@ export type APIScopes =
   | 'read-achievement-definitions'
   | 'update-achievement-definitions'
   | 'delete-achievement-definitions'
+  | 'create-appointments'
+  | 'read-appointments'
+  | 'update-appointments'
+  | 'delete-appointments'
+  | 'create-appointment-definitions'
+  | 'read-appointment-definitions'
+  | 'update-appointment-definitions'
+  | 'delete-appointment-definitions'
+  | 'create-appointment-queues'
+  | 'read-appointment-queues'
+  | 'update-appointment-queues'
+  | 'delete-appointment-queues'
+  | 'create-appointment-waitlists'
+  | 'read-appointment-waitlists'
+  | 'update-appointment-waitlists'
+  | 'delete-appointment-waitlists'
   | 'read-benefits'
   | 'create-benefits'
   | 'delete-benefits'
@@ -184,4 +201,8 @@ export type APIToken = {
   client: Client
   usage: Array<any>
   user: User
+}
+
+export type APITokenResponse = PaginationResponse & {
+  data: APIToken[]
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './omneo'
 export * from './address'
+export * from './appointment'
 export * from './auth'
 export * from './achievement'
 export * from './transaction'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,10 @@ export default defineConfig(({ command, mode }) => {
     },
     test: {
       env,
-      testTimeout: 40000
+      testTimeout: 40000,
+      // afterAll teardown fires a serial run of live DELETEs, which can exceed
+      // the 10s default when the whole suite is running in parallel
+      hookTimeout: 40000
     }
   }
 })


### PR DESCRIPTION
This pull request introduces the Appointments resource to both the admin (`Omneo`) and customer (`ID`) SDK clients, providing full CRUD support and visibility endpoints for appointments. It also adds comprehensive documentation and updates the repository guidance for contributors and AI agents.

**Appointments resource integration:**

- **Omneo (admin) client:**
  - Registered new resources: `appointments`, `appointmentDefinitions`, `appointmentQueues`, and `appointmentWaitlists` as public properties on the `Omneo` class, making them available for use. [[1]](diffhunk://#diff-b4c9cf2c48cf4c2368eb49cd61eb8a81b61cf517792ef62aa5a6877724e9f8faR60-R63) [[2]](diffhunk://#diff-b4c9cf2c48cf4c2368eb49cd61eb8a81b61cf517792ef62aa5a6877724e9f8faR82-R85)

- **ID (customer) client:**
  - Added `appointments` as a property on the `profile` resource, exposing appointment operations to the customer surface. [[1]](diffhunk://#diff-e1bf96d2924b6090540bae5538a76ea8dc01b26fc6abc9633a1fa29ec4b7ab48R13) [[2]](diffhunk://#diff-e1bf96d2924b6090540bae5538a76ea8dc01b26fc6abc9633a1fa29ec4b7ab48R39)
  - Implemented the `ProfileAppointments` class with methods for `get`, `list`, `create`, `update`, `delete`, and `listVisibleDefinitions`, following the repository's resource pattern.

**Documentation and guidance:**

- **Resource documentation:**
  - Added a detailed `README.md` for the new `profile/appointments` resource, documenting all methods with usage examples.

- **Repository guidance:**
  - Introduced `AGENTS.md`, a comprehensive style and architecture guide for contributors and AI agents, covering project structure, resource conventions, code style, and testing practices.
  - Added `CLAUDE.md` with a pointer to `AGENTS.md` and a critical note about running live integration tests.